### PR TITLE
Ensure user has access to repo for linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/lifecycle-automation/compare/0.1.0...HEAD
 
+### Added
+
+-   Link repository to channel command and event handlers
+
 ### Changed
 
 -   Updated package scripts to have standard names and be platform

--- a/graphql/subscription/pushToUnmappedRepo.graphql
+++ b/graphql/subscription/pushToUnmappedRepo.graphql
@@ -9,6 +9,7 @@ subscription pushToUnmappedRepo
       }
       org {
         provider {
+          providerId
           url
           apiUrl
           gitUrl

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "dependencies": {
     "@atomist/automation-client": {
-      "version": "https://atomist.jfrog.io/atomist/npm-dev/@atomist/automation-client/-/@atomist/automation-client-0.2.6-20171028190013.tgz",
-      "integrity": "sha1-V6X2NQZ5x4CexmFy/mzDGeznlUc=",
+      "version": "https://atomist.jfrog.io/atomist/npm-dev/@atomist/automation-client/-/@atomist/automation-client-0.2.6-20171030234846.tgz",
+      "integrity": "sha1-ffdmoooay1hkKCcD4mCxFtsWD1c=",
       "requires": {
         "@atomist/microgrammar": "0.7.0",
         "@atomist/slack-messages": "0.12.0",

--- a/src/handlers/command/slack/AssociateRepo.ts
+++ b/src/handlers/command/slack/AssociateRepo.ts
@@ -70,8 +70,8 @@ export class AssociateRepo implements HandleCommand {
 
     private checkRepo(token: string, url: string, repo: string, owner: string): Promise<boolean> {
         return github.api(token, url).repos.get({ owner, repo })
-            .then(_ => true)
-            .catch(_ => false);
+            .then(x => true)
+            .catch(e => false);
     }
 
     private noRepoMessage(repo: string, owner: string): SlackMessage {

--- a/src/handlers/command/slack/AssociateRepo.ts
+++ b/src/handlers/command/slack/AssociateRepo.ts
@@ -2,6 +2,7 @@ import {
     CommandHandler,
     MappedParameter,
     Parameter,
+    Secret,
     Tags,
 } from "@atomist/automation-client/decorators";
 import {
@@ -10,9 +11,14 @@ import {
     HandlerContext,
     HandlerResult,
     MappedParameters,
+    Secrets,
     Success,
 } from "@atomist/automation-client/Handlers";
-import * as graphql from "../../../typings/types";
+import { SlackMessage } from "@atomist/slack-messages/SlackMessages";
+
+import { AddBotToSlackChannel, LinkSlackChannelToRepo } from "../../../typings/types";
+import * as github from "../github/gitHubApi";
+
 /**
  * Link a repository and channel.
  */
@@ -26,6 +32,12 @@ export class AssociateRepo implements HandleCommand {
     @MappedParameter(MappedParameters.GitHubOwner)
     public owner: string;
 
+    @MappedParameter(MappedParameters.GitHubApiUrl)
+    public apiUrl: string = "https://api.github.com/";
+
+    @Secret(Secrets.userToken(["repo"]))
+    public githubToken: string;
+
     @Parameter({
         displayName: "Repository Name",
         description: "name of the repository to link",
@@ -37,15 +49,34 @@ export class AssociateRepo implements HandleCommand {
     public repo: string;
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
-        return ctx.graphClient.executeMutationFromFile<graphql.AddBotToSlackChannel.Mutation,
-            graphql.AddBotToSlackChannel.Variables>(
-                "graphql/mutation/addBotToSlackChannel",
-                { channelId: this.channelId })
-            .then(_ => ctx.graphClient.executeMutationFromFile<graphql.LinkSlackChannelToRepo.Mutation,
-                graphql.LinkSlackChannelToRepo.Variables>(
-                    "graphql/mutation/linkSlackChannelToRepo",
-                    { channelId: this.channelId, repo: this.repo, owner: this.owner }))
+        return this.checkRepo(this.githubToken, this.apiUrl, this.repo, this.owner)
+            .then(repoExists => {
+                if (!repoExists) {
+                    ctx.messageClient.respond(this.noRepoMessage(this.repo, this.owner));
+                    return;
+                }
+                return ctx.graphClient.executeMutationFromFile<AddBotToSlackChannel.Mutation,
+                    AddBotToSlackChannel.Variables>(
+                    "graphql/mutation/addBotToSlackChannel",
+                    { channelId: this.channelId })
+                    .then(_ => ctx.graphClient.executeMutationFromFile<LinkSlackChannelToRepo.Mutation,
+                        LinkSlackChannelToRepo.Variables>(
+                        "graphql/mutation/linkSlackChannelToRepo",
+                        { channelId: this.channelId, repo: this.repo, owner: this.owner }));
+            })
             .then(() => Success)
             .catch(e => failure(e));
     }
+
+    private checkRepo(token: string, url: string, repo: string, owner: string): Promise<boolean> {
+        return github.api(token, url).repos.get({ owner, repo })
+            .then(_ => true)
+            .catch(_ => false);
+    }
+
+    private noRepoMessage(repo: string, owner: string): SlackMessage {
+        return { text: `The repository ${owner}/${repo} either does not exist or you do not have access to it.` };
+
+    }
+
 }

--- a/src/handlers/event/push/PushToUnmappedRepo.ts
+++ b/src/handlers/event/push/PushToUnmappedRepo.ts
@@ -95,13 +95,21 @@ function getDisabledRepos(preferences: graphql.PushToUnmappedRepo._Preferences[]
     return mappingConfig[disabledReposConfigKey] as string[];
 }
 
+export function repoString(repo: graphql.PushToUnmappedRepo.Repo): string {
+    if (!repo) {
+        return "!";
+    }
+    const provider = (repo.org && repo.org.provider) ? `${repo.org.provider.providerId}:` : "";
+    return `${provider}${repo.owner}:${repo.name}`;
+}
+
 export function leaveRepoUnmapped(
     repo: graphql.PushToUnmappedRepo.Repo,
     chatId: graphql.PushToUnmappedRepo.ChatId,
 ): boolean {
 
-    const slug = `${repo.owner}/${repo.name}`;
-    return getDisabledRepos(chatId.preferences).some(r => r === repo.name || r === slug);
+    const repoStr = repoString(repo);
+    return getDisabledRepos(chatId.preferences).some(r => r === repoStr);
 }
 
 export function mapRepoMessage(
@@ -159,7 +167,7 @@ ${slack.codeLine(`@atomist repo owner=${repo.owner} repo=${repo.name}`)}`;
     };
 
     const stopText = `Stop receiving similar suggestions for`;
-    disabledRepos.push(slug);
+    disabledRepos.push(repoString(repo));
     const stopButton = buttonForCommand({ text: slug }, "SetUserPreference", {
         key: repoMappingConfigKey,
         name: disabledReposConfigKey,

--- a/src/typings/types.d.ts
+++ b/src/typings/types.d.ts
@@ -4154,6 +4154,7 @@ export namespace PushToUnmappedRepo {
   } 
 
   export type Provider = {
+    providerId?: string; 
     url?: string; 
     apiUrl?: string; 
     gitUrl?: string; 

--- a/test/handlers/event/push/PushToUnmappedRepoTest.ts
+++ b/test/handlers/event/push/PushToUnmappedRepoTest.ts
@@ -1,7 +1,8 @@
 import "mocha";
 import * as assert from "power-assert";
 
-import { leaveRepoUnmapped } from "../../../../src/handlers/event/push/PushToUnmappedRepo";
+import { leaveRepoUnmapped, mapRepoMessage } from "../../../../src/handlers/event/push/PushToUnmappedRepo";
+// import { PushToUnmappedRepo } from "../../../../src/typings/types";
 
 describe("PushToUnmappedRepo", () => {
 
@@ -46,4 +47,156 @@ describe("PushToUnmappedRepo", () => {
         });
 
     });
+
+    describe("mapRepoMessage", () => {
+
+        it("should send a message offering to create channel and link a repo to it", () => {
+            const repo = {
+                name: "sin-city",
+                owner: "grievous-angel",
+                channels: [],
+                org: {
+                    provider: {
+                        apiUrl: "https://ghe.gram-parsons.com/v3/",
+                        url: "https://ghe.gram-parsons.com/",
+                    },
+                    chatTeam: {
+                        channels: [
+                            {
+                                channelId: "C1000WED",
+                                name: "1000-wedding",
+                            },
+                        ],
+                    },
+                },
+            };
+            const chatId = {
+                screenName: "gram",
+                preferences: [{
+                    name: "repo_mapping_flow",
+                    value: JSON.stringify({}),
+                }],
+            };
+            const repoLink = "<https://ghe.gram-parsons.com/grievous-angel/sin-city|grievous-angel/sin-city>";
+            const channelText = "*#sin-city*";
+            const msg = mapRepoMessage(repo, chatId);
+            assert(msg.attachments.length === 3);
+            const linkMsg = msg.attachments[0];
+            const hintMsg = msg.attachments[1];
+            const stopMsg = msg.attachments[2];
+            assert(linkMsg.pretext.indexOf(repoLink) > 0);
+            assert(linkMsg.pretext.indexOf(channelText) > 0);
+            assert(linkMsg.actions.length === 1);
+            assert(linkMsg.actions[0].text === "Go ahead");
+            assert(linkMsg.actions[0].type === "button");
+            const command = (linkMsg.actions[0] as any).command;
+            assert(command.name === "CreateChannel");
+            assert(command.parameters.apiUrl === "https://ghe.gram-parsons.com/v3/");
+            assert(command.parameters.channel === "sin-city");
+            assert(command.parameters.owner === "grievous-angel");
+            assert(command.parameters.repo === "sin-city");
+            const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
+'@atomist repo owner=grievous-angel repo=sin-city'`;
+            assert(hintMsg.fallback === hintFallBack);
+            const stopText = "Stop receiving similar suggestions for";
+            assert(stopMsg.text === stopText);
+            assert(stopMsg.fallback === stopText);
+            assert(stopMsg.actions.length === 2);
+            assert(stopMsg.actions[0].text === "grievous-angel/sin-city");
+            assert(stopMsg.actions[0].type === "button");
+            const repoStopCmd = (stopMsg.actions[0] as any).command;
+            assert(repoStopCmd.name === "SetUserPreference");
+            assert(repoStopCmd.parameters.key === "repo_mapping_flow");
+            assert(repoStopCmd.parameters.name === "disabled_repos");
+            assert(repoStopCmd.parameters.value === `["grievous-angel/sin-city"]`);
+            assert(stopMsg.actions[1].text === "All Repos");
+            assert(stopMsg.actions[1].type === "button");
+            const allStopCmd = (stopMsg.actions[1] as any).command;
+            assert(allStopCmd.name === "SetUserPreference");
+            assert(allStopCmd.parameters.key === "dm");
+            assert(allStopCmd.parameters.name === "disable_for_mapRepo");
+            assert(allStopCmd.parameters.value === "true");
+        });
+
+        it("should send a message offering to link a repo to existing channel", () => {
+            const repo = {
+                name: "sin-city",
+                owner: "grievous-angel",
+                channels: [],
+                org: {
+                    provider: {
+                        apiUrl: "https://ghe.gram-parsons.com/v3/",
+                        url: "https://ghe.gram-parsons.com/",
+                    },
+                    chatTeam: {
+                        channels: [
+                            {
+                                channelId: "C1000WED",
+                                name: "1000-wedding",
+                            },
+                            {
+                                channelId: "C51NC1TY",
+                                name: "sin-city",
+                            },
+                        ],
+                    },
+                },
+            };
+            const chatId = {
+                screenName: "gram",
+                preferences: [{
+                    name: "repo_mapping_flow",
+                    value: JSON.stringify({
+                        disabled_repos: [
+                            "grievous-angel/a-song-for-you",
+                            "grievous-angel/in-my-hour-of-darkness",
+                            "grievous-angel/return-of-the-grievous-angel",
+                        ],
+                    }),
+                }],
+            };
+            const repoLink = "<https://ghe.gram-parsons.com/grievous-angel/sin-city|grievous-angel/sin-city>";
+            const channelText = "<#C51NC1TY>";
+            const msg = mapRepoMessage(repo, chatId);
+            assert(msg.attachments.length === 3);
+            const linkMsg = msg.attachments[0];
+            const hintMsg = msg.attachments[1];
+            const stopMsg = msg.attachments[2];
+            assert(linkMsg.pretext.indexOf(repoLink) > 0);
+            assert(linkMsg.pretext.indexOf(channelText) > 0);
+            assert(linkMsg.actions.length === 1);
+            assert(linkMsg.actions[0].text === "Go ahead");
+            assert(linkMsg.actions[0].type === "button");
+            const command = (linkMsg.actions[0] as any).command;
+            assert(command.name === "AssociateRepo");
+            assert(command.parameters.apiUrl === "https://ghe.gram-parsons.com/v3/");
+            assert(command.parameters.channelId === "C51NC1TY");
+            assert(command.parameters.owner === "grievous-angel");
+            assert(command.parameters.repo === "sin-city");
+            const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
+'@atomist repo owner=grievous-angel repo=sin-city'`;
+            assert(hintMsg.fallback === hintFallBack);
+            const stopText = "Stop receiving similar suggestions for";
+            assert(stopMsg.text === stopText);
+            assert(stopMsg.fallback === stopText);
+            assert(stopMsg.actions.length === 2);
+            assert(stopMsg.actions[0].text === "grievous-angel/sin-city");
+            assert(stopMsg.actions[0].type === "button");
+            const repoStopCmd = (stopMsg.actions[0] as any).command;
+            assert(repoStopCmd.name === "SetUserPreference");
+            assert(repoStopCmd.parameters.key === "repo_mapping_flow");
+            assert(repoStopCmd.parameters.name === "disabled_repos");
+            // tslint:disable-next-line:max-line-length
+            assert(repoStopCmd.parameters.value === `["grievous-angel/a-song-for-you","grievous-angel/in-my-hour-of-darkness","grievous-angel/return-of-the-grievous-angel","grievous-angel/sin-city"]`);
+            assert(stopMsg.actions[1].text === "All Repos");
+            assert(stopMsg.actions[1].type === "button");
+            const allStopCmd = (stopMsg.actions[1] as any).command;
+            assert(allStopCmd.name === "SetUserPreference");
+            assert(allStopCmd.parameters.key === "dm");
+            assert(allStopCmd.parameters.name === "disable_for_mapRepo");
+            assert(allStopCmd.parameters.value === "true");
+        });
+
+    });
+
 });


### PR DESCRIPTION
Make sure directory exists and user has access to it prior to trying
to link it to a channel.  Use AssociateRepo.handle in CreateChannel
rather than duplicating code.  Improve text of message.  Add tests.

Towards #14