### PR TITLE
Update link unmapped repo message after action

### DIFF
--- a/src/handlers/command/preferences/SetUserPreference.ts
+++ b/src/handlers/command/preferences/SetUserPreference.ts
@@ -26,19 +26,53 @@ export class SetUserPreference implements HandleCommand {
     @MappedParameter(MappedParameters.SlackUser)
     public requester: string;
 
-    @Parameter({ description: "preference key to set", pattern: /^.*$/ })
+    @Parameter({
+        displayName: "Preference Category",
+        description: "category of preferences under which you want to set a preference",
+        pattern: /^\S+$/,
+        validInput: "non-whitespace characters, 1 to 100 characters in length",
+        minLength: 1,
+        maxLength: 100,
+        required: true,
+    })
     public key: string;
 
-    @Parameter({ description: "preference name to set", pattern: /^.*$/ })
+    @Parameter({
+        displayName: "Preference Name",
+        description: "key of preference to set",
+        pattern: /^\S+$/,
+        validInput: "non-whitespace characters, 1 to 100 characters in length",
+        minLength: 1,
+        maxLength: 100,
+        required: true,
+    })
     public name: string;
 
-    @Parameter({ description: "value to set the preference to", pattern: /^.*$/ })
+    @Parameter({
+        displayName: "Preference Value",
+        description: "value to set the preference to, typically stringified JSON but can be just a string",
+        pattern: /^[\S\s]*$/,
+        validInput: "a string 1000 characters or less",
+        minLength: 0,
+        maxLength: 1000,
+        required: true,
+    })
     public value: string;
 
-    @Parameter({ description: "id of the message to use for confirmation", pattern: /^.*$/, required: false })
+    @Parameter({
+        displayable: false,
+        description: "id of the message to use for confirmation",
+        pattern: /^\S*$/,
+        required: false,
+    })
     public id: string;
 
-    @Parameter({ description: "label to show in confirmation message", pattern: /^.*$/, required: false })
+    @Parameter({
+        displayable: false,
+        description: "label to show in confirmation message",
+        pattern: /^.*$/,
+        required: false,
+    })
     public label: string;
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
@@ -87,7 +121,6 @@ export class SetUserPreference implements HandleCommand {
                 };
                 return ctx.messageClient.respond(msg, { id: this.id });
             })
-            .then(() => Success)
-            .catch(err => failure(err));
+            .then(() => Success, err => failure(err));
     }
 }

--- a/src/handlers/command/slack/CreateChannel.ts
+++ b/src/handlers/command/slack/CreateChannel.ts
@@ -55,6 +55,9 @@ export class CreateChannel implements HandleCommand {
     })
     public repo: string;
 
+    @Parameter({ pattern: /^\S*$/, displayable: false, required: false })
+    public msgId: string;
+
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
         return ctx.graphClient.executeMutationFromFile<CreateSlackChannel.Mutation, CreateSlackChannel.Variables>(
             "graphql/mutation/createSlackChannel", { name: this.channel })
@@ -66,6 +69,7 @@ export class CreateChannel implements HandleCommand {
                 associateRepo.userId = this.userId;
                 associateRepo.githubToken = this.githubToken;
                 associateRepo.repo = this.repo;
+                associateRepo.msgId = this.msgId;
                 return associateRepo.handle(ctx);
             })
             .catch(e => failure(e));

--- a/test/handlers/event/push/PushToUnmappedRepoTest.ts
+++ b/test/handlers/event/push/PushToUnmappedRepoTest.ts
@@ -2,8 +2,10 @@ import "mocha";
 import * as assert from "power-assert";
 
 import {
+    extractScreenNameFromMapRepoMessageId,
     leaveRepoUnmapped,
     mapRepoMessage,
+    mapRepoMessageId,
     repoString,
 } from "../../../../src/handlers/event/push/PushToUnmappedRepo";
 
@@ -77,6 +79,24 @@ describe("PushToUnmappedRepo", () => {
 
     });
 
+    describe("mapRepoMessageId", () => {
+        const owner = "alicia-keys";
+        const repo = "girl-on-fire";
+        const screenName = "augello";
+
+        it("should provide a message ID with repo and screen name", () => {
+            const id = mapRepoMessageId(owner, repo, screenName);
+            assert(id.includes(owner));
+            assert(id.includes(repo));
+            assert(id.includes(screenName));
+        });
+
+        it("should return a message ID from which we can get a screen name", () => {
+            assert(extractScreenNameFromMapRepoMessageId(mapRepoMessageId(owner, repo, screenName)) === screenName);
+        });
+
+    });
+
     describe("mapRepoMessage", () => {
 
         it("should send a message offering to create channel and link a repo to it", () => {
@@ -123,20 +143,13 @@ describe("PushToUnmappedRepo", () => {
             const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
 '@atomist repo owner=grievous-angel repo=sin-city'`;
             assert(hintMsg.fallback === hintFallBack);
-            const stopText = "Stop receiving similar suggestions for";
-            assert(stopMsg.text === stopText);
-            assert(stopMsg.fallback === stopText);
-            assert(stopMsg.actions.length === 2);
-            assert(stopMsg.actions[0].text === "grievous-angel/sin-city");
+            const stopText = "stop receiving similar suggestions for all repositories";
+            assert(stopMsg.text.includes(stopText));
+            assert(stopMsg.fallback.includes(stopText));
+            assert(stopMsg.actions.length === 1);
+            assert(stopMsg.actions[0].text === "All Repositories");
             assert(stopMsg.actions[0].type === "button");
-            const repoStopCmd = (stopMsg.actions[0] as any).command;
-            assert(repoStopCmd.name === "SetUserPreference");
-            assert(repoStopCmd.parameters.key === "repo_mapping_flow");
-            assert(repoStopCmd.parameters.name === "disabled_repos");
-            assert(repoStopCmd.parameters.value === `["grievous-angel:sin-city"]`);
-            assert(stopMsg.actions[1].text === "All Repositories");
-            assert(stopMsg.actions[1].type === "button");
-            const allStopCmd = (stopMsg.actions[1] as any).command;
+            const allStopCmd = (stopMsg.actions[0] as any).command;
             assert(allStopCmd.name === "SetUserPreference");
             assert(allStopCmd.parameters.key === "dm");
             assert(allStopCmd.parameters.name === "disable_for_mapRepo");
@@ -202,21 +215,13 @@ describe("PushToUnmappedRepo", () => {
             const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
 '@atomist repo owner=grievous-angel repo=sin-city'`;
             assert(hintMsg.fallback === hintFallBack);
-            const stopText = "Stop receiving similar suggestions for";
-            assert(stopMsg.text === stopText);
-            assert(stopMsg.fallback === stopText);
-            assert(stopMsg.actions.length === 2);
-            assert(stopMsg.actions[0].text === "grievous-angel/sin-city");
+            const stopText = "stop receiving similar suggestions for all repositories";
+            assert(stopMsg.text.includes(stopText));
+            assert(stopMsg.fallback.includes(stopText));
+            assert(stopMsg.actions.length === 1);
+            assert(stopMsg.actions[0].text === "All Repositories");
             assert(stopMsg.actions[0].type === "button");
-            const repoStopCmd = (stopMsg.actions[0] as any).command;
-            assert(repoStopCmd.name === "SetUserPreference");
-            assert(repoStopCmd.parameters.key === "repo_mapping_flow");
-            assert(repoStopCmd.parameters.name === "disabled_repos");
-            // tslint:disable-next-line:max-line-length
-            assert(repoStopCmd.parameters.value === `["sierra_records:grievous-angel:a-song-for-you","sierra_records:grievous-angel:in-my-hour-of-darkness","sierra_records:grievous-angel:return-of-the-grievous-angel","sierra_records:grievous-angel:sin-city"]`);
-            assert(stopMsg.actions[1].text === "All Repositories");
-            assert(stopMsg.actions[1].type === "button");
-            const allStopCmd = (stopMsg.actions[1] as any).command;
+            const allStopCmd = (stopMsg.actions[0] as any).command;
             assert(allStopCmd.name === "SetUserPreference");
             assert(allStopCmd.parameters.key === "dm");
             assert(allStopCmd.parameters.name === "disable_for_mapRepo");


### PR DESCRIPTION

After someone takes action on the unmapped repo linking message,
update the message to indicate the action taken.  Remove TTL unmapped
repo message so each user only gets it once.

Add metadata to SetUserPreference command handler parameters.