### PR TITLE
Add BotJoinedChannel, clean GitHubWebhookCreated 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 -   Link repository to channel command and event handlers
+-   Send message when bot joins a channel
 
 ### Changed
 

--- a/graphql/subscription/botJoinedChannel.graphql
+++ b/graphql/subscription/botJoinedChannel.graphql
@@ -1,0 +1,35 @@
+subscription BotJoinedChannel {
+  UserJoinedChannel {
+    user {
+      isAtomistBot
+      screenName
+      userId
+    }
+    channel {
+      botInvitedSelf
+      channelId
+      name
+      repos {
+        name
+        owner
+        org {
+          provider {
+            url
+          }
+        }
+      }
+      team {
+        orgs {
+          owner
+          provider {
+            apiUrl
+          }
+          repo {
+            name
+            owner
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/subscription/githubOrgWebhook.graphql
+++ b/graphql/subscription/githubOrgWebhook.graphql
@@ -1,17 +1,18 @@
 subscription GitHubWebhookCreated
 {
-    GitHubOrgWebhook {
-        org {
-            chatTeam {
-                members(isOwner: "true") {
-                    screenName
-                }
-                channels {
-                    name
-                    channelId
-                }
-            }
+  GitHubOrgWebhook {
+    org {
+      chatTeam {
+        members {
+          isAtomistBot
+          isOwner
+          screenName
         }
+        channels {
+          name
+          channelId
+        }
+      }
     }
+  }
 }
-

--- a/graphql/subscription/pushToUnmappedRepo.graphql
+++ b/graphql/subscription/pushToUnmappedRepo.graphql
@@ -19,6 +19,10 @@ subscription PushToUnmappedRepo
             channelId
             name
           }
+          members(isAtomistBot: "true") {
+            isAtomistBot
+            screenName
+          }
           preferences {
             name
             value

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -34,11 +34,16 @@ import {
     ConfigureDirectMessageUserPreferences,
 } from "./handlers/command/preferences/ConfigureDirectMessageUserPreferences";
 import { SetUserPreference } from "./handlers/command/preferences/SetUserPreference";
+import { AddBotToChannel } from "./handlers/command/slack/AddBotToChannel";
+import { AssociateRepo } from "./handlers/command/slack/AssociateRepo";
 import { CreateChannel } from "./handlers/command/slack/CreateChannel";
+import { LinkOwnerRepo } from "./handlers/command/slack/LinkOwnerRepo";
 import { LinkRepo } from "./handlers/command/slack/LinkRepo";
 import { ListRepoLinks } from "./handlers/command/slack/ListRepoLinks";
+import { NoLinkRepo } from "./handlers/command/slack/NoLinkRepo";
 import { RestartTravisBuild } from "./handlers/command/travis/RestartTravisBuild";
 import { NotifyPusherOnBuild } from "./handlers/event/build/NotifyPusherOnBuild";
+import { BotJoinedChannel } from "./handlers/event/channellink/BotJoinedChannel";
 import { ChannelLinkCreated } from "./handlers/event/channellink/ChannelLinkCreated";
 import { CommentToIssueCommentLifecycle } from "./handlers/event/comment/CommentToIssueCommentLifecycle";
 import { CommentToPullRequestCommentLifecycle } from "./handlers/event/comment/CommentToPullRequestCommentLifecycle";
@@ -144,9 +149,13 @@ export const configuration = {
         () => new SetUserPreference(),
 
         // slack
-        () => new LinkRepo(),
+        () => new AddBotToChannel(),
+        () => new AssociateRepo(),
         () => new CreateChannel(),
+        () => new LinkOwnerRepo(),
+        () => new LinkRepo(),
         // () => new ListRepoLinks(),
+        () => new NoLinkRepo(),
 
         // travis
         () => new RestartTravisBuild(),
@@ -161,6 +170,7 @@ export const configuration = {
         () => new NotifyPusherOnBuild(),
 
         // channellink
+        () => new BotJoinedChannel(),
         () => new ChannelLinkCreated(),
 
         // parentimpact

--- a/src/handlers/command/github/InstallGitHubWebhook.ts
+++ b/src/handlers/command/github/InstallGitHubWebhook.ts
@@ -23,6 +23,7 @@ import {
     loadChatTeam,
 } from "../../../util/helpers";
 import { sendUnMappedRepoMessage } from "../../event/push/PushToUnmappedRepo";
+import { DefaultBotName } from "../slack/LinkRepo";
 import * as github from "./gitHubApi";
 
 @CommandHandler("Install webhook for a whole organization", "install org-webhook", "install github org-webhook")
@@ -136,16 +137,16 @@ export class InstallGitHubRepoWebhook implements HandleCommand {
                     .then(results => {
                         if (results[0] && results[1]) {
                             const repo: graphql.PushToUnmappedRepo.Repo = {
-                               owner: this.owner,
-                               name: this.repo,
-                               org: {
-                                   chatTeam: {
-                                       channels: results[1].channels,
-                                   },
-                                   provider: {},
-                               },
+                                owner: this.owner,
+                                name: this.repo,
+                                org: {
+                                    chatTeam: {
+                                        channels: results[1].channels,
+                                    },
+                                    provider: {},
+                                },
                             };
-                            return sendUnMappedRepoMessage([results[0]], repo, ctx);
+                            return sendUnMappedRepoMessage([results[0]], repo, ctx, DefaultBotName);
                         } else {
                             return Success;
                         }

--- a/src/handlers/command/slack/AddBotToChannel.ts
+++ b/src/handlers/command/slack/AddBotToChannel.ts
@@ -1,0 +1,41 @@
+import {
+    CommandHandler,
+    failure,
+    HandleCommand,
+    HandlerContext,
+    HandlerResult,
+    MappedParameter,
+    MappedParameters,
+    Parameter,
+    Secret,
+    Secrets,
+    Success,
+    Tags,
+} from "@atomist/automation-client/Handlers";
+import * as slack from "@atomist/slack-messages/SlackMessages";
+
+import { AddBotToSlackChannel } from "../../../typings/types";
+import { extractScreenNameFromMapRepoMessageId } from "../../event/push/PushToUnmappedRepo";
+import * as github from "../github/gitHubApi";
+import { checkRepo, noRepoMessage } from "./AssociateRepo";
+
+export function addBotToSlackChannel(ctx: HandlerContext, channelId: string): Promise<AddBotToSlackChannel.Mutation> {
+    return ctx.graphClient.executeMutationFromFile<AddBotToSlackChannel.Mutation, AddBotToSlackChannel.Variables>(
+        "graphql/mutation/addBotToSlackChannel",
+        { channelId },
+    );
+}
+
+@CommandHandler("Invite the Atomist Bot to a channel")
+@Tags("slack", "bot")
+export class AddBotToChannel implements HandleCommand {
+
+    @MappedParameter(MappedParameters.SlackChannel)
+    public channelId: string;
+
+    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+        return addBotToSlackChannel(ctx, this.channelId)
+            .then(() => Success, failure);
+    }
+
+}

--- a/src/handlers/command/slack/AssociateRepo.ts
+++ b/src/handlers/command/slack/AssociateRepo.ts
@@ -1,0 +1,100 @@
+import {
+    CommandHandler,
+    failure,
+    HandleCommand,
+    HandlerContext,
+    HandlerResult,
+    MappedParameter,
+    MappedParameters,
+    Parameter,
+    Secret,
+    Secrets,
+    Success,
+    Tags,
+} from "@atomist/automation-client/Handlers";
+import * as slack from "@atomist/slack-messages/SlackMessages";
+
+import { AddBotToSlackChannel, InviteUserToSlackChannel } from "../../../typings/types";
+import { extractScreenNameFromMapRepoMessageId } from "../../event/push/PushToUnmappedRepo";
+import * as github from "../github/gitHubApi";
+import { addBotToSlackChannel } from "./AddBotToChannel";
+import { linkSlackChannelToRepo } from "./LinkRepo";
+
+export function checkRepo(token: string, url: string, repo: string, owner: string): Promise<boolean> {
+    return github.api(token, url).repos.get({ owner, repo })
+        .then(x => true, e => false);
+}
+
+export function noRepoMessage(repo: string, owner: string): slack.SlackMessage {
+    return { text: `The repository ${owner}/${repo} either does not exist or you do not have access to it.` };
+}
+
+export function inviteUserToSlackChannel(
+    ctx: HandlerContext,
+    channelId: string,
+    userId: string,
+): Promise<InviteUserToSlackChannel.Mutation> {
+
+    return ctx.graphClient.executeMutationFromFile<InviteUserToSlackChannel.Mutation,
+        InviteUserToSlackChannel.Variables>(
+        "graphql/mutation/inviteUserToSlackChannel",
+        { channelId, userId },
+    );
+}
+
+@CommandHandler("Invite bot, link a repository, and invite user to channel")
+@Tags("slack", "repo")
+export class AssociateRepo implements HandleCommand {
+
+    @MappedParameter(MappedParameters.SlackChannel)
+    public channelId: string;
+
+    @MappedParameter(MappedParameters.GitHubOwner)
+    public owner: string;
+
+    @MappedParameter(MappedParameters.GitHubApiUrl)
+    public apiUrl: string = "https://api.github.com/";
+
+    @MappedParameter(MappedParameters.SlackUser)
+    public userId: string;
+
+    @Secret(Secrets.userToken("repo"))
+    public githubToken: string;
+
+    @Parameter({
+        displayName: "Repository Name",
+        description: "name of the repository to link",
+        pattern: /^[-.\w]+$/,
+        minLength: 1,
+        maxLength: 100,
+        required: true,
+    })
+    public repo: string;
+
+    @Parameter({ pattern: /^\S*$/, displayable: false, required: false })
+    public msgId: string;
+
+    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+        return checkRepo(this.githubToken, this.apiUrl, this.repo, this.owner)
+            .then(repoExists => {
+                if (!repoExists) {
+                    ctx.messageClient.respond(noRepoMessage(this.repo, this.owner));
+                    return;
+                }
+                return addBotToSlackChannel(ctx, this.channelId)
+                    .then(() => linkSlackChannelToRepo(ctx, this.channelId, this.repo, this.owner))
+                    .then(() => inviteUserToSlackChannel(ctx, this.channelId, this.userId))
+                    .then(() => {
+                        if (this.msgId) {
+                            const screenName = extractScreenNameFromMapRepoMessageId(this.msgId);
+                            const msg = `Linked ${slack.bold(this.owner + "/" + this.repo)} to ` +
+                                `${slack.channel(this.channelId)} and invited you to the channel.`;
+                            ctx.messageClient.addressUsers(msg, screenName, { id: this.msgId });
+                        }
+                        return Success;
+                    });
+            })
+            .then(() => Success, failure);
+    }
+
+}

--- a/src/handlers/command/slack/CreateChannel.ts
+++ b/src/handlers/command/slack/CreateChannel.ts
@@ -13,7 +13,14 @@ import {
 } from "@atomist/automation-client/Handlers";
 
 import { CreateSlackChannel } from "../../../typings/types";
-import { LinkRepo } from "./LinkRepo";
+import { AssociateRepo } from "./AssociateRepo";
+
+export function createChannel(ctx: HandlerContext, channelName: string): Promise<CreateSlackChannel.Mutation> {
+    return ctx.graphClient.executeMutationFromFile<CreateSlackChannel.Mutation, CreateSlackChannel.Variables>(
+        "graphql/mutation/createSlackChannel",
+        { name: channelName },
+    );
+}
 
 /**
  * Create a channel and link it to a repository.
@@ -58,10 +65,9 @@ export class CreateChannel implements HandleCommand {
     public msgId: string;
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
-        return ctx.graphClient.executeMutationFromFile<CreateSlackChannel.Mutation, CreateSlackChannel.Variables>(
-            "graphql/mutation/createSlackChannel", { name: this.channel })
+        return createChannel(ctx, this.channel)
             .then(channel => {
-                const associateRepo = new LinkRepo();
+                const associateRepo = new AssociateRepo();
                 associateRepo.channelId = channel.createSlackChannel[0].id;
                 associateRepo.owner = this.owner;
                 associateRepo.apiUrl = this.apiUrl;

--- a/src/handlers/command/slack/LinkOwnerRepo.ts
+++ b/src/handlers/command/slack/LinkOwnerRepo.ts
@@ -1,0 +1,77 @@
+import {
+    CommandHandler,
+    failure,
+    HandleCommand,
+    HandlerContext,
+    HandlerResult,
+    MappedParameter,
+    MappedParameters,
+    Parameter,
+    Secret,
+    Secrets,
+    Success,
+    Tags,
+} from "@atomist/automation-client/Handlers";
+import * as slack from "@atomist/slack-messages/SlackMessages";
+
+import * as github from "../github/gitHubApi";
+import { LinkRepo } from "./LinkRepo";
+
+@CommandHandler("Link a repository, provided as an owner/repo slug, and channel")
+@Tags("slack", "repo")
+export class LinkOwnerRepo implements HandleCommand {
+
+    @MappedParameter(MappedParameters.SlackChannel)
+    public channelId: string;
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public channelName: string;
+
+    @MappedParameter(MappedParameters.GitHubApiUrl)
+    public apiUrl: string = "https://api.github.com/";
+
+    @Secret(Secrets.userToken("repo"))
+    public githubToken: string;
+
+    @Parameter({
+        displayName: "Repository Slug",
+        description: "'owner/name' of the repository to link",
+        pattern: /^[-.\w]+\/[-.\w]+$/,
+        minLength: 1,
+        maxLength: 200,
+        required: true,
+    })
+    public slug: string;
+
+    @Parameter({ pattern: /^\S*$/, displayable: false, required: false })
+    public msgId: string;
+
+    @Parameter({ pattern: /^[\S\s]*$/, displayable: false, required: false })
+    public msg: string = "";
+
+    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+        const slugParts = this.slug.split("/", 2);
+        if (!slugParts || slugParts.length !== 2 || !slugParts[0] || !slugParts[1]) {
+            const err = `failed to parse repo slug '${this.slug}' into owner and name, ` +
+                `not linking to #${this.channelName}`;
+            console.error(err);
+            return ctx.messageClient.respond(err)
+                .then(() => Success, failure);
+        }
+        const owner = slugParts[0];
+        const name = slugParts[1];
+        const linkRepo = new LinkRepo();
+        linkRepo.channelId = this.channelId;
+        linkRepo.channelName = this.channelName;
+        linkRepo.apiUrl = this.apiUrl;
+        linkRepo.githubToken = this.githubToken;
+        linkRepo.name = name;
+        linkRepo.owner = owner;
+        linkRepo.msgId = this.msgId;
+        linkRepo.msg = this.msg;
+
+        return linkRepo.handle(ctx)
+            .then(() => Success, failure);
+    }
+
+}

--- a/src/handlers/command/slack/LinkRepo.ts
+++ b/src/handlers/command/slack/LinkRepo.ts
@@ -14,32 +14,49 @@ import {
 } from "@atomist/automation-client/Handlers";
 import * as slack from "@atomist/slack-messages/SlackMessages";
 
-import {
-    AddBotToSlackChannel,
-    InviteUserToSlackChannel,
-    LinkSlackChannelToRepo,
-} from "../../../typings/types";
-import { extractScreenNameFromMapRepoMessageId } from "../../event/push/PushToUnmappedRepo";
+import { LinkSlackChannelToRepo } from "../../../typings/types";
 import * as github from "../github/gitHubApi";
+import { checkRepo, noRepoMessage } from "./AssociateRepo";
 
-/**
- * Link a repository and channel.
- */
-@CommandHandler("Link a repository and channel", "repo")
+export const DefaultBotName = "atomist";
+
+export function linkSlackChannelToRepo(
+    ctx: HandlerContext,
+    channelId: string,
+    repo: string,
+    owner: string,
+): Promise<LinkSlackChannelToRepo.Mutation> {
+
+    return ctx.graphClient.executeMutationFromFile<LinkSlackChannelToRepo.Mutation, LinkSlackChannelToRepo.Variables>(
+        "graphql/mutation/linkSlackChannelToRepo",
+        { channelId, repo, owner },
+    );
+}
+
+@CommandHandler("Link a repository and channel")
 @Tags("slack", "repo")
 export class LinkRepo implements HandleCommand {
 
+    public static linkRepoCommand(
+        botName: string = DefaultBotName,
+        owner: string = "OWNER",
+        repo: string = "REPO",
+    ): string {
+
+        return `@${botName} repo owner=${owner} name=${repo}`;
+    }
+
     @MappedParameter(MappedParameters.SlackChannel)
     public channelId: string;
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public channelName: string;
 
     @MappedParameter(MappedParameters.GitHubOwner)
     public owner: string;
 
     @MappedParameter(MappedParameters.GitHubApiUrl)
     public apiUrl: string = "https://api.github.com/";
-
-    @MappedParameter(MappedParameters.SlackUser)
-    public userId: string;
 
     @Secret(Secrets.userToken("repo"))
     public githubToken: string;
@@ -52,52 +69,30 @@ export class LinkRepo implements HandleCommand {
         maxLength: 100,
         required: true,
     })
-    public repo: string;
+    public name: string;
 
     @Parameter({ pattern: /^\S*$/, displayable: false, required: false })
     public msgId: string;
 
+    @Parameter({ pattern: /^[\S\s]*$/, displayable: false, required: false })
+    public msg: string = "";
+
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
-        return this.checkRepo(this.githubToken, this.apiUrl, this.repo, this.owner)
+        return checkRepo(this.githubToken, this.apiUrl, this.name, this.owner)
             .then(repoExists => {
                 if (!repoExists) {
-                    ctx.messageClient.respond(this.noRepoMessage(this.repo, this.owner));
+                    ctx.messageClient.respond(noRepoMessage(this.name, this.owner));
                     return;
                 }
-                return ctx.graphClient.executeMutationFromFile<AddBotToSlackChannel.Mutation,
-                    AddBotToSlackChannel.Variables>(
-                    "graphql/mutation/addBotToSlackChannel",
-                    { channelId: this.channelId })
-                    .then(x => ctx.graphClient.executeMutationFromFile<LinkSlackChannelToRepo.Mutation,
-                        LinkSlackChannelToRepo.Variables>(
-                        "graphql/mutation/linkSlackChannelToRepo",
-                        { channelId: this.channelId, repo: this.repo, owner: this.owner }))
-                    .then(x => ctx.graphClient.executeMutationFromFile<InviteUserToSlackChannel.Mutation,
-                        InviteUserToSlackChannel.Variables>(
-                        "graphql/mutation/inviteUserToSlackChannel",
-                        { channelId: this.channelId, userId: this.userId }))
-                    .then(x => {
+                return linkSlackChannelToRepo(ctx, this.channelId, this.name, this.owner)
+                    .then(() => {
                         if (this.msgId) {
-                            const screenName = extractScreenNameFromMapRepoMessageId(this.msgId);
-                            const msg = `Linked ${slack.bold(this.owner + "/" + this.repo)} to ` +
-                                `${slack.channel(this.channelId)} and invited you to the channel.`;
-                            ctx.messageClient.addressUsers(msg, screenName, { id: this.msgId });
+                            ctx.messageClient.addressChannels(this.msg, this.channelName, { id: this.msgId });
                         }
                         return Success;
                     });
             })
-            .then(x => Success, e => failure(e));
-    }
-
-    private checkRepo(token: string, url: string, repo: string, owner: string): Promise<boolean> {
-        return github.api(token, url).repos.get({ owner, repo })
-            .then(x => true)
-            .catch(e => false);
-    }
-
-    private noRepoMessage(repo: string, owner: string): slack.SlackMessage {
-        return { text: `The repository ${owner}/${repo} either does not exist or you do not have access to it.` };
-
+            .then(() => Success, failure);
     }
 
 }

--- a/src/handlers/command/slack/NoLinkRepo.ts
+++ b/src/handlers/command/slack/NoLinkRepo.ts
@@ -1,0 +1,47 @@
+import {
+    CommandHandler,
+    failure,
+    HandleCommand,
+    HandlerContext,
+    HandlerResult,
+    MappedParameter,
+    MappedParameters,
+    Parameter,
+    Secret,
+    Secrets,
+    Success,
+    Tags,
+} from "@atomist/automation-client/Handlers";
+import * as slack from "@atomist/slack-messages/SlackMessages";
+
+import {
+    AddBotToSlackChannel,
+    InviteUserToSlackChannel,
+    LinkSlackChannelToRepo,
+} from "../../../typings/types";
+import { extractScreenNameFromMapRepoMessageId } from "../../event/push/PushToUnmappedRepo";
+import * as github from "../github/gitHubApi";
+import { checkRepo, noRepoMessage } from "./AssociateRepo";
+
+@CommandHandler("replace repo channel linking prompt with instructions")
+@Tags("slack", "repo")
+export class NoLinkRepo implements HandleCommand {
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public channelName: string;
+
+    @Parameter({ pattern: /^\S*$/, displayable: false, required: false })
+    public msgId: string;
+
+    @Parameter({ pattern: /^[\S\s]*$/, displayable: false, required: false })
+    public msg: string = "";
+
+    public handle(ctx: HandlerContext): Promise<HandlerResult> {
+        if (this.msgId) {
+            return ctx.messageClient.addressChannels(this.msg, this.channelName, { id: this.msgId })
+                .then(() => Success, failure);
+        }
+        return Promise.resolve(Success);
+    }
+
+}

--- a/src/handlers/event/channellink/BotJoinedChannel.ts
+++ b/src/handlers/event/channellink/BotJoinedChannel.ts
@@ -1,0 +1,161 @@
+import * as GraphQL from "@atomist/automation-client/graph/graphQL";
+import {
+    EventFired,
+    EventHandler,
+    failure,
+    HandleEvent,
+    HandlerContext,
+    HandlerResult,
+    Success,
+} from "@atomist/automation-client/Handlers";
+import {
+    buttonForCommand,
+    menuForCommand,
+    MenuSpecification,
+    OptionGroup,
+} from "@atomist/automation-client/spi/message/MessageClient";
+import * as slack from "@atomist/slack-messages/SlackMessages";
+import * as _ from "lodash";
+
+import * as graphql from "../../../typings/types";
+import { repoChannelName, repoSlackLink, repoSlug } from "../../../util/helpers";
+import { LinkOwnerRepo } from "../../command/slack/LinkOwnerRepo";
+import { DefaultBotName, LinkRepo } from "../../command/slack/LinkRepo";
+import { NoLinkRepo } from "../../command/slack/NoLinkRepo";
+
+@EventHandler("Display a helpful message when the bot joins a channel",
+    GraphQL.subscriptionFromFile("graphql/subscription/botJoinedChannel"))
+export class BotJoinedChannel implements HandleEvent<graphql.BotJoinedChannel.Subscription> {
+
+    public handle(e: EventFired<graphql.BotJoinedChannel.Subscription>, ctx: HandlerContext): Promise<HandlerResult> {
+
+        return Promise.all(e.data.UserJoinedChannel.map(j => {
+            if (!j.user) {
+                console.log(`UserJoinedChannel.user is false, probably not the bot joining a channel`);
+                return Success;
+            }
+            if (j.user.isAtomistBot !== "true") {
+                console.log(`user joining the channel is not the bot: ${j.user.screenName}`);
+                return Success;
+            }
+            if (!j.channel) {
+                console.log(`UserJoinedChannel.channel is false, strange`);
+                return Success;
+            }
+            if (!j.channel.name) {
+                console.log(`the channel has no name, odd`);
+                return Success;
+            }
+            const channelName = j.channel.name;
+            if (j.channel.botInvitedSelf) {
+                console.log(`bot invited self to #${channelName}, not sending message`);
+                return Success;
+            }
+            const botName = (j.user.screenName) ? j.user.screenName : DefaultBotName;
+
+            const helloText = `Hello! Now I can respond to messages beginning with @${botName}. ` +
+                `To see some options, try \`@${botName} help\``;
+
+            if (j.channel.repos && j.channel.repos.length > 0) {
+                const linkedRepoNames = j.channel.repos.map(r => repoSlackLink(r));
+                const msg = `${helloText}
+I will post GitHub notifications about ${linkedRepoNames.join(", ")} here.`;
+                return ctx.messageClient.addressChannels(msg, channelName);
+            }
+
+            if (!j.channel.team || !j.channel.team.orgs || j.channel.team.orgs.length < 1) {
+                const msg = `${helloText}
+I won't be able to do much without GitHub integration, though. Run \`@atomist enroll org\` to set that up.`;
+                return ctx.messageClient.addressChannels(msg, channelName);
+            }
+            const orgs = j.channel.team.orgs;
+            const apiUrls = _.uniq(orgs.filter(o => o && o.provider && o.provider.apiUrl).map(o => o.provider.apiUrl));
+            if (apiUrls && apiUrls.length > 1) {
+                console.warn(`multiple GitHub providers found, ${JSON.stringify(apiUrls)}, using the first`);
+            }
+            const apiUrl = (apiUrls && apiUrls[0]) ? apiUrls[0] : undefined;
+
+            const allRepos = _.flatMap(orgs, o => (o && o.repo) ? o.repo : []);
+            if (allRepos.length < 1) {
+                const owners = orgs.map(o => o.owner);
+                let ownerText: string;
+                if (owners.length > 2) {
+                    owners[owners.length - 1] = "or " + owners[owners.length - 1];
+                    ownerText = owners.join(", ");
+                } else if (owners.length === 2) {
+                    ownerText = owners.join(" or ");
+                } else if (owners.length === 1) {
+                    ownerText = owners[0];
+                }
+                ownerText = (ownerText) ? ` for ${ownerText}` : "";
+                const msg = `${helloText}
+I don't see any repositories in GitHub${ownerText}.`;
+                return ctx.messageClient.addressChannels(msg, channelName);
+            }
+
+            const msgId = `channel_link/bot_joined_channel/${channelName}`;
+
+            const matchyRepos = allRepos.filter(r =>
+                repoChannelName(r.name).indexOf(channelName) > -1 ||
+                channelName.indexOf(repoChannelName(r.name)) > -1).slice(0, 2);
+            const actions: slack.Action[] = [];
+            matchyRepos.forEach(r => {
+                const linkRepo = new LinkRepo();
+                linkRepo.apiUrl = apiUrl;
+                linkRepo.channelId = j.channel.channelId;
+                linkRepo.channelName = channelName;
+                linkRepo.owner = r.owner;
+                linkRepo.name = r.name;
+                linkRepo.msgId = msgId;
+                linkRepo.msg = helloText;
+                actions.push(buttonForCommand({ text: repoSlug(r) }, linkRepo));
+            });
+
+            const menu: MenuSpecification = {
+                text: "repository...",
+                options: repoOptions(orgs),
+            };
+            const linkRepoSlug = new LinkOwnerRepo();
+            linkRepoSlug.apiUrl = apiUrl;
+            linkRepoSlug.channelId = j.channel.channelId;
+            linkRepoSlug.channelName = channelName;
+            linkRepoSlug.msgId = msgId;
+            linkRepoSlug.msg = helloText;
+            actions.push(menuForCommand(menu, linkRepoSlug, "slug"));
+
+            const noLinkRepo = new NoLinkRepo();
+            noLinkRepo.channelName = channelName;
+            noLinkRepo.msgId = msgId;
+            const linkCmd = LinkRepo.linkRepoCommand(botName);
+            noLinkRepo.msg = `${helloText}
+OK. If you want to link a repository later, type \`${linkCmd}\``;
+            actions.push(buttonForCommand({ text: "No thanks" }, noLinkRepo));
+
+            const msgText = "Since I'm here, would you like me to post notifications " +
+                "from a GitHub repository to this channel?";
+            const linkMsg: slack.SlackMessage = {
+                text: helloText,
+                attachments: [
+                    {
+                        text: msgText,
+                        fallback: msgText,
+                        mrkdwn_in: ["text"],
+                        actions,
+                    },
+                ],
+            };
+            return ctx.messageClient.addressChannels(linkMsg, channelName, { id: msgId });
+        })).then(() => Success, failure);
+    }
+}
+
+export function repoOptions(orgs: graphql.BotJoinedChannel.Orgs[]): OptionGroup[] {
+    return orgs.map(o => {
+        return {
+            text: `${o.owner}/`,
+            options: o.repo.map(r => {
+                return { text: r.name, value: repoSlug(r) };
+            }),
+        };
+    });
+}

--- a/src/handlers/event/channellink/ChannelLinkCreated.ts
+++ b/src/handlers/event/channellink/ChannelLinkCreated.ts
@@ -11,10 +11,9 @@ import {
 import {
     escape,
     SlackMessage,
-    url,
 } from "@atomist/slack-messages/SlackMessages";
 import * as graphql from "../../../typings/types";
-import { repoUrl } from "../../../util/helpers";
+import { repoSlackLink } from "../../../util/helpers";
 
 @EventHandler("Display an unlink message when a channel is linked",
     GraqhQL.subscriptionFromFile("graphql/subscription/channelLinkCreated"))
@@ -24,9 +23,8 @@ export class ChannelLinkCreated implements HandleEvent<graphql.ChannelLinkCreate
                   ctx: HandlerContext): Promise<HandlerResult> {
         const channelName = event.data.ChannelLink[0].channel.name || event.data.ChannelLink[0].channel.normalizedName;
         const repo = event.data.ChannelLink[0].repo;
-        const msg = `${url(repoUrl(repo), `${repo.owner}/${repo.name}`)} is now linked to this \
-channel. I will send activity from that repository here. To turn this \
-off at any time, type \`@atomist repos\` and click the button.`;
+        const msg = `${repoSlackLink(repo)} is now linked to this channel. I will send activity from that \
+repository here. To turn this off, type \`@atomist repos\` and click the "unlink ${repo.name}" button.`;
 
         const repoMsg: SlackMessage = {
             attachments: [{

--- a/src/handlers/event/webhook/GitHubWebhookCreated.ts
+++ b/src/handlers/event/webhook/GitHubWebhookCreated.ts
@@ -9,10 +9,12 @@ import {
     Success,
 } from "@atomist/automation-client/Handlers";
 import { buttonForCommand } from "@atomist/automation-client/spi/message/MessageClient";
-import { SlackMessage } from "@atomist/slack-messages/SlackMessages";
+import { Attachment, codeLine, SlackMessage } from "@atomist/slack-messages/SlackMessages";
 import * as _ from "lodash";
+
 import * as graphql from "../../../typings/types";
-import { LinkRepo } from "../../command/slack/LinkRepo";
+import { AddBotToChannel } from "../../command/slack/AddBotToChannel";
+import { DefaultBotName } from "../../command/slack/LinkRepo";
 
 // list of channels we look for to create buttons
 const Channels = ["dev", "engineering", "development", "devops"];
@@ -21,55 +23,46 @@ const Channels = ["dev", "engineering", "development", "devops"];
     GraqhQL.subscriptionFromFile("graphql/subscription/githubOrgWebhook"))
 export class GitHubWebhookCreated implements HandleEvent<graphql.GitHubWebhookCreated.Subscription> {
 
-    public handle(event: EventFired<graphql.GitHubWebhookCreated.Subscription>,
-                  ctx: HandlerContext): Promise<HandlerResult> {
-        let channels = _.get(event.data, "GitHubOrgWebhook[0].org.chatTeam.channels", []) || [];
-        if (channels) {
-            channels = channels.filter(c => Channels.some(cc => cc === c.name));
+    public handle(
+        event: EventFired<graphql.GitHubWebhookCreated.Subscription>,
+        ctx: HandlerContext,
+    ): Promise<HandlerResult> {
+
+        const members = _.get(event.data, "GitHubOrgWebhook[0].org.chatTeam.members", []) as
+            graphql.GitHubWebhookCreated.Members[];
+        if (!members || members.length < 1) {
+            return Promise.resolve(Success);
         }
-
-        const owner = _.get(event.data, "GitHubOrgWebhook[0].org.chatTeam.members[0].screenName");
-
+        const owner = members.find(m => m.isOwner === "true");
         if (!owner) {
             return Promise.resolve(Success);
         }
+        const ownerName = owner.screenName;
+        const bot = members.find(m => m.isAtomistBot === "true");
+        const botName = (bot && bot.screenName) ? bot.screenName : DefaultBotName;
 
+        const channels = ((_.get(event.data, "GitHubOrgWebhook[0].org.chatTeam.channels", []) || []) as
+            graphql.GitHubWebhookCreated.Channels[])
+            .filter(c => Channels.some(cc => cc === c.name));
+
+        const welcomeAttachment: Attachment = {
+            fallback: `Invite me to any channel where your team works using '/invite @${botName}'.`,
+            mrkdwn_in: ["text"],
+        };
+        let suffix = ".";
         if (channels.length > 0) {
-            const msg = `I can now tell you about GitHub events like pushes, PRs, and issues. \
-Invite me to any channel where your team works with \`/invite @atomist\`, or \
-click one of the buttons below.`;
-            const welcomeMsg: SlackMessage = {
-                attachments: [
-                    {
-                        fallback: msg,
-                        text: msg,
-                        mrkdwn_in: ["text"],
-                        actions: channels.map(c => createAssociateRepoButton(c)),
-                    }],
-            };
-            return ctx.messageClient.addressUsers(welcomeMsg, owner)
-                .then(() => Success, failure);
-        } else {
-            const msg = `I can now tell you about GitHub events like pushes, PRs, and issues.
-Invite me to any channel where your team works with \`/invite @atomist\`.`;
-            const welcomeMsg: SlackMessage = {
-                attachments: [
-                    {
-                        fallback: msg,
-                        text: msg,
-                        mrkdwn_in: ["text"],
-                    },
-                ],
-            };
-            return ctx.messageClient.addressUsers(welcomeMsg, owner)
-                .then(() => Success, failure);
+            suffix = " or click one of the buttons below.";
+            welcomeAttachment.actions = channels.map(c => {
+                const addBotCmd = new AddBotToChannel();
+                addBotCmd.channelId = c.channelId;
+                return buttonForCommand({ text: `#${c.name}` }, addBotCmd);
+            });
         }
-    }
-}
+        welcomeAttachment.text = `Invite me to any channel where your team works using ` +
+            codeLine(`/invite @${botName}`) + suffix;
 
-function createAssociateRepoButton(channel: graphql.GitHubWebhookCreated.Channels) {
-    const handler = new LinkRepo();
-    handler.repo = channel.name;
-    handler.channelId = channel.channelId;
-    return buttonForCommand({text: `#${channel.name}`}, handler);
+        const welcomeMsg: SlackMessage = { attachments: [welcomeAttachment] };
+        return ctx.messageClient.addressUsers(welcomeMsg, ownerName)
+            .then(() => Success, failure);
+    }
 }

--- a/src/typings/types.d.ts
+++ b/src/typings/types.d.ts
@@ -1293,6 +1293,66 @@ export namespace AutoMergeOnStatus {
     body?: string | null; 
   } 
 }
+export namespace BotJoinedChannel {
+  export type Variables = {
+  }
+
+  export type Subscription = {
+    UserJoinedChannel?: UserJoinedChannel[] | null; 
+  } 
+
+  export type UserJoinedChannel = {
+    user?: User | null; 
+    channel?: Channel | null; 
+  } 
+
+  export type User = {
+    isAtomistBot?: string | null; 
+    screenName?: string | null; 
+    userId?: string | null; 
+  } 
+
+  export type Channel = {
+    botInvitedSelf?: boolean | null; 
+    channelId?: string | null; 
+    name?: string | null; 
+    repos?: Repos[] | null; 
+    team?: Team | null; 
+  } 
+
+  export type Repos = {
+    name?: string | null; 
+    owner?: string | null; 
+    org?: Org | null; 
+  } 
+
+  export type Org = {
+    provider?: Provider | null; 
+  } 
+
+  export type Provider = {
+    url?: string | null; 
+  } 
+
+  export type Team = {
+    orgs?: Orgs[] | null; 
+  } 
+
+  export type Orgs = {
+    owner?: string | null; 
+    provider?: _Provider | null; 
+    repo?: Repo[] | null; 
+  } 
+
+  export type _Provider = {
+    apiUrl?: string | null; 
+  } 
+
+  export type Repo = {
+    name?: string | null; 
+    owner?: string | null; 
+  } 
+}
 export namespace BranchToPullRequestLifecycle {
   export type Variables = {
   }
@@ -2481,6 +2541,8 @@ export namespace GitHubWebhookCreated {
   } 
 
   export type Members = {
+    isAtomistBot?: string | null; 
+    isOwner?: string | null; 
     screenName?: string | null; 
   } 
 
@@ -4533,12 +4595,18 @@ export namespace PushToUnmappedRepo {
 
   export type ChatTeam = {
     channels?: _Channels[] | null; 
+    members?: Members[] | null; 
     preferences?: Preferences[] | null; 
   } 
 
   export type _Channels = {
     channelId?: string | null; 
     name?: string | null; 
+  } 
+
+  export type Members = {
+    isAtomistBot?: string | null; 
+    screenName?: string | null; 
   } 
 
   export type Preferences = {

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -40,8 +40,24 @@ export function truncateCommitMessage(message: string, repo: any): string {
     return titleParts.slice(0, i + addNext).join("");
 }
 
+/**
+ * Generate GitHub repository "slug", i.e., owner/repo.
+ *
+ * @param repo repository with .owner and .name
+ * @return owner/name string
+ */
 export function repoSlug(repo: any): string {
     return `${repo.owner}/${repo.name}`;
+}
+
+/**
+ * Generate valid Slack channel name for a repository name.
+ *
+ * @param repoName valid GitHub repository name
+ * @return valid Slack channel name based on repository name
+ */
+export function repoChannelName(repoName: string): string {
+    return (repoName) ? repoName.substring(0, 21).replace(/\./g, "_").toLowerCase() : repoName;
 }
 
 export function branchUrl(repo: any, branch: string): string {
@@ -49,7 +65,7 @@ export function branchUrl(repo: any, branch: string): string {
 }
 
 export function htmlUrl(repo: any): string {
-    if (repo.org != null && repo.org.provider != null && repo.org.provider.url != null) {
+    if (repo.org && repo.org.provider && repo.org.provider.url) {
         let providerUrl = repo.org.provider.url;
         if (providerUrl.slice(-1) === "/") {
             providerUrl = providerUrl.slice(0, -1);
@@ -61,7 +77,7 @@ export function htmlUrl(repo: any): string {
 }
 
 export function apiUrl(repo: any): string {
-    if (repo.org != null && repo.org.provider != null && repo.org.provider.url != null) {
+    if (repo.org && repo.org.provider && repo.org.provider.url) {
         let providerUrl = repo.org.provider.apiUrl;
         if (providerUrl.slice(-1) === "/") {
             providerUrl = providerUrl.slice(0, -1);
@@ -74,6 +90,10 @@ export function apiUrl(repo: any): string {
 
 export function repoUrl(repo: any): string {
     return `${htmlUrl(repo)}/${repoSlug(repo)}`;
+}
+
+export function repoSlackLink(repo: any): string {
+    return url(repoUrl(repo), repoSlug(repo));
 }
 
 export function userUrl(repo: any, login: string): string {
@@ -345,7 +365,7 @@ export function loadRepoByNameAndOwner(ctx: HandlerContext, name: string, owner:
 export function loadChatTeam(ctx: HandlerContext): Promise<graphql.ChatTeam.ChatTeam> {
     return ctx.graphClient.executeQueryFromFile<graphql.ChatTeam.Query, graphql.ChatTeam.Variables>(
         "graphql/query/chatTeam",
-        { })
+        {})
         .then(result => {
             return _.get(result, "ChatTeam[0]");
         })

--- a/test/handlers/command/slack/LinkRepoTest.ts
+++ b/test/handlers/command/slack/LinkRepoTest.ts
@@ -1,0 +1,32 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import { LinkRepo } from "../../../../src/handlers/command/slack/LinkRepo";
+
+describe("LinkRepo", () => {
+
+    describe("linkRepoCommand", () => {
+
+        const r = "sams-town";
+        const o = "the-killers";
+        const b = "when-you_were-young";
+
+        it("should respond with defaults", () => {
+            assert(LinkRepo.linkRepoCommand() === `@atomist repo owner=OWNER name=REPO`);
+        });
+
+        it("should respond with bot", () => {
+            assert(LinkRepo.linkRepoCommand(b) === `@${b} repo owner=OWNER name=REPO`);
+        });
+
+        it("should respond with repo and owner", () => {
+            assert(LinkRepo.linkRepoCommand(b, o) === `@${b} repo owner=${o} name=REPO`);
+        });
+
+        it("should respond with repo, owner, and bot", () => {
+            assert(LinkRepo.linkRepoCommand(b, o, r) === `@${b} repo owner=${o} name=${r}`);
+        });
+
+    });
+
+});

--- a/test/handlers/event/channelLink/BotJoinedChannelTest.ts
+++ b/test/handlers/event/channelLink/BotJoinedChannelTest.ts
@@ -1,0 +1,149 @@
+import "mocha";
+import * as assert from "power-assert";
+
+import * as slack from "@atomist/slack-messages/SlackMessages";
+
+import { BotJoinedChannel, repoOptions } from "../../../../src/handlers/event/channellink/BotJoinedChannel";
+
+describe("BotJoinedChannel", () => {
+
+    const orgs = [
+        {
+            owner: "jon",
+            repo: [
+                {
+                    name: "7-mary-3",
+                    owner: "jon",
+                },
+                {
+                    name: "79-charles",
+                    owner: "jon",
+                },
+            ],
+        },
+        {
+            owner: "ponch",
+            repo: [
+                {
+                    name: "7-mary-4",
+                    owner: "ponch",
+                },
+                {
+                    name: "79-mary-4",
+                    owner: "ponch",
+                },
+            ],
+        },
+    ];
+
+    describe("repoOptions", () => {
+
+        it("should create an option group", () => {
+            const e = [
+                {
+                    text: "jon/",
+                    options: [
+                        {
+                            text: "7-mary-3",
+                            value: "jon/7-mary-3",
+                        },
+                        {
+                            text: "79-charles",
+                            value: "jon/79-charles",
+                        },
+                    ],
+                },
+                {
+                    text: "ponch/",
+                    options: [
+                        {
+                            text: "7-mary-4",
+                            value: "ponch/7-mary-4",
+                        },
+                        {
+                            text: "79-mary-4",
+                            value: "ponch/79-mary-4",
+                        },
+                    ],
+                },
+            ];
+            assert.deepEqual(repoOptions(orgs), e);
+        });
+
+    });
+
+    describe("handle", () => {
+
+        const event = {
+            data: {
+                UserJoinedChannel: [{
+                    user: {
+                        isAtomistBot: "true",
+                        screenName: "atomist_bot",
+                        userId: "U1234567",
+                    },
+                    channel: {
+                        botInvitedSelf: false,
+                        channelId: "CHP87654P",
+                        name: "ponch",
+                        repos: [
+                            {
+                                name: "n",
+                                owner: "n",
+                                org: {
+                                    provider: {
+                                        url: "https://ghe.chp.gov/",
+                                    },
+                                },
+                            },
+                        ],
+                        team: {
+                            orgs: [
+                                {
+                                    owner: "n",
+                                    provider: {
+                                        apiUrl: "https://ghe.chp.gov/v3/",
+                                    },
+                                    repo: [
+                                        {
+                                            name: "n",
+                                            owner: "n",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    },
+                }],
+            },
+            extensions: {
+                type: "READ_ONLY",
+                operationName: "BotJoinedChannel",
+            },
+        };
+
+        it("should send a message", done => {
+            let sent = false;
+            const ctx: any = {
+                messageClient: {
+                    addressChannels(
+                        msg: string | slack.SlackMessage,
+                        channelNames: string | string[],
+                        options?: any,
+                    ): Promise<any> {
+                        sent = true;
+                        return Promise.resolve(true);
+                    },
+                },
+            };
+            const h = new BotJoinedChannel();
+            h.handle(event, ctx)
+                .then(() => {
+                    assert(sent);
+                })
+                .then(done, done);
+        });
+
+    });
+
+});

--- a/test/handlers/event/push/PushToUnmappedRepoTest.ts
+++ b/test/handlers/event/push/PushToUnmappedRepoTest.ts
@@ -1,6 +1,7 @@
 import "mocha";
 import * as assert from "power-assert";
 
+import { DefaultBotName } from "../../../../src/handlers/command/slack/LinkRepo";
 import {
     extractScreenNameFromMapRepoMessageId,
     leaveRepoUnmapped,
@@ -124,7 +125,7 @@ describe("PushToUnmappedRepo", () => {
             };
             const repoLink = "<https://github.com/grievous-angel/sin-city|grievous-angel/sin-city>";
             const channelText = "*#sin-city*";
-            const msg = mapRepoMessage(repo, chatId);
+            const msg = mapRepoMessage(repo, chatId, DefaultBotName);
             assert(msg.attachments.length === 3);
             const linkMsg = msg.attachments[0];
             const hintMsg = msg.attachments[1];
@@ -141,7 +142,7 @@ describe("PushToUnmappedRepo", () => {
             assert(command.parameters.owner === "grievous-angel");
             assert(command.parameters.repo === "sin-city");
             const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
-'@atomist repo owner=grievous-angel repo=sin-city'`;
+'@atomist repo owner=grievous-angel name=sin-city'`;
             assert(hintMsg.fallback === hintFallBack);
             const stopText = "stop receiving similar suggestions for all repositories";
             assert(stopMsg.text.includes(stopText));
@@ -196,7 +197,8 @@ describe("PushToUnmappedRepo", () => {
             };
             const repoLink = "<https://ghe.gram-parsons.com/grievous-angel/sin-city|grievous-angel/sin-city>";
             const channelText = "<#C51NC1TY>";
-            const msg = mapRepoMessage(repo, chatId);
+            const bot = "hillman";
+            const msg = mapRepoMessage(repo, chatId, bot);
             assert(msg.attachments.length === 3);
             const linkMsg = msg.attachments[0];
             const hintMsg = msg.attachments[1];
@@ -207,13 +209,13 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[0].text === "Go ahead");
             assert(linkMsg.actions[0].type === "button");
             const command = (linkMsg.actions[0] as any).command;
-            assert(command.name === "LinkRepo");
+            assert(command.name === "AssociateRepo");
             assert(command.parameters.apiUrl === "https://ghe.gram-parsons.com/v3/");
             assert(command.parameters.channelId === "C51NC1TY");
             assert(command.parameters.owner === "grievous-angel");
             assert(command.parameters.repo === "sin-city");
-            const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
-'@atomist repo owner=grievous-angel repo=sin-city'`;
+            const hintFallBack = `or '/invite @${bot}' me to a relevant channel and type
+'@${bot} repo owner=grievous-angel name=sin-city'`;
             assert(hintMsg.fallback === hintFallBack);
             const stopText = "stop receiving similar suggestions for all repositories";
             assert(stopMsg.text.includes(stopText));

--- a/test/handlers/event/webhook/GitHubWebhookCreatedTest.ts
+++ b/test/handlers/event/webhook/GitHubWebhookCreatedTest.ts
@@ -16,6 +16,7 @@ describe("GitHubWebhookCreated", () => {
                         chatTeam: {
                             members: [
                                 {
+                                    isOwner: "true",
                                     screenName: "cd",
                                 },
                             ],
@@ -51,11 +52,9 @@ describe("GitHubWebhookCreated", () => {
                     assert(sm.attachments[0].actions.length === 2);
                     assert(sm.attachments[0].actions[0].text === "#dev");
                     assert((sm.attachments[0].actions[0] as any).command.parameters.channelId === "C7UR196MB");
-                    assert((sm.attachments[0].actions[0] as any).command.parameters.repo === "dev");
 
                     assert(sm.attachments[0].actions[1].text === "#engineering");
                     assert((sm.attachments[0].actions[1] as any).command.parameters.channelId === "D18G4L88J");
-                    assert((sm.attachments[0].actions[1] as any).command.parameters.repo === "engineering");
                     messageSend = true;
                     return Promise.resolve();
                 },
@@ -66,8 +65,8 @@ describe("GitHubWebhookCreated", () => {
             .then(result => {
                 assert(result.code === 0);
                 assert(messageSend);
-                done();
-            });
+            })
+            .then(done, done);
     });
 
     it("should generate a message if there are no channels", done => {
@@ -78,6 +77,7 @@ describe("GitHubWebhookCreated", () => {
                         chatTeam: {
                             members: [
                                 {
+                                    isOwner: "true",
                                     screenName: "cd",
                                 },
                             ],
@@ -121,8 +121,8 @@ describe("GitHubWebhookCreated", () => {
             .then(result => {
                 assert(result.code === 0);
                 assert(messageSend);
-                done();
-            });
+            })
+            .then(done, done);
     });
 
     it("should generate a message if there are null channels", done => {
@@ -133,6 +133,7 @@ describe("GitHubWebhookCreated", () => {
                         chatTeam: {
                             members: [
                                 {
+                                    isOwner: "true",
                                     screenName: "cd",
                                 },
                             ],
@@ -163,7 +164,50 @@ describe("GitHubWebhookCreated", () => {
             .then(result => {
                 assert(result.code === 0);
                 assert(messageSend);
-                done();
-            });
+            })
+            .then(done, done);
+    });
+
+    it("should generate a message if channels is undefined", done => {
+        const event = {
+            data: {
+                GitHubOrgWebhook: [{
+                    org: {
+                        chatTeam: {
+                            members: [
+                                {
+                                    isOwner: "true",
+                                    screenName: "cd",
+                                },
+                            ],
+                            channels: undefined,
+                        },
+                    },
+                }],
+            },
+            extensions: {
+                operationName: "GitHubWebhookCreated",
+            },
+        };
+
+        let messageSend = false;
+        const ctx: any = {
+            messageClient: {
+                addressUsers(msg: string | SlackMessage, userNames: string | string[]): Promise<any> {
+                    assert(userNames === "cd");
+                    const sm = msg as SlackMessage;
+                    assert(!sm.attachments[0].actions);
+                    messageSend = true;
+                    return Promise.resolve();
+                },
+            },
+        };
+
+        handler.handle(event, ctx)
+            .then(result => {
+                assert(result.code === 0);
+                assert(messageSend);
+            })
+            .then(done, done);
     });
 });

--- a/test/util/helpersTests.ts
+++ b/test/util/helpersTests.ts
@@ -9,6 +9,7 @@ import {
     isDmDisabled,
     linkGitHubUsers,
     linkIssues,
+    repoSlackLink,
     truncateCommitMessage,
 } from "../../src/util/helpers";
 
@@ -190,6 +191,34 @@ Fixes #1950.
             const e = `Changed &lt;some things&gt; so &amp; issue identified by ` +
                 `<https://github.com/elvis/presley/issues/1929|elv...>`;
             assert(truncateCommitMessage(m, repo) === e);
+        });
+
+    });
+
+    describe("repoSlackLink", () => {
+
+        it("should return a github.com link", () => {
+            const r = {
+                name: "music",
+                owner: "palace",
+                org: {},
+            };
+            const e = `<https://github.com/palace/music|palace/music>`;
+            assert(repoSlackLink(r) === e);
+        });
+
+        it("should return a github provider link", () => {
+            const r = {
+                name: "music",
+                owner: "palace",
+                org: {
+                    provider: {
+                        url: "http://bonnie.prince.billy/github/",
+                    },
+                },
+            };
+            const e = `<http://bonnie.prince.billy/github/palace/music|palace/music>`;
+            assert(repoSlackLink(r) === e);
         });
 
     });


### PR DESCRIPTION
Add BotJoinedChannel handler to say hello and possibly offer to link a
repo to it.  Add simple tests.  The handle test just makes sure the
wiring works.  More should be added.

Break up things associated with repo/channel management so they can
more easily be composed.

Get real bot name in event subscriptions a few places.

Use objects when creating Slack buttons.

Do not talk about channel/repo linking in GitHubWebhookCreated
handler.  It does not do that, it just allows the owner to add the bot
to a channel.  Once there, the bot can suggest linking.