### PR TITLE
fixes endless loop when parsing CircleCI workflow config

### DIFF
--- a/src/handlers/event/push/workflow/CircleWorkflow.ts
+++ b/src/handlers/event/push/workflow/CircleWorkflow.ts
@@ -30,15 +30,16 @@ export function circleWorkflowtoStages(workflow: graphql.PushToPushLifecycle.Wor
     }];
     const visitedJobs = ["build"];
 
-    while (orderedStages.length <= stages.length) {
+    let stagesRequiringOnlyVisitedJobs: Stage[] = [];
+    do {
         const remainingStages: Stage[] = _.clone(stages);
         _.remove(remainingStages, s => _.includes(orderedStages, s));
-        const stagesRequireOnlyVisitedJobs: Stage[] = remainingStages.
+        stagesRequiringOnlyVisitedJobs = remainingStages.
             filter(s => _.every(s.require, r => _.includes(visitedJobs, r)));
-        const newlyVisitedJobs: string[] = _.uniq(_.flatMap(stagesRequireOnlyVisitedJobs, s => s.jobs));
+        const newlyVisitedJobs: string[] = _.uniq(_.flatMap(stagesRequiringOnlyVisitedJobs, s => s.jobs));
         newlyVisitedJobs.forEach(j => visitedJobs.push(j));
-        stagesRequireOnlyVisitedJobs.forEach(s => orderedStages.push(s));
-    }
+        stagesRequiringOnlyVisitedJobs.forEach(s => orderedStages.push(s));
+    } while (stagesRequiringOnlyVisitedJobs.length > 0);
 
     const workflowStages: WorkflowStage[] = _.map(orderedStages, s => {
         const buildsInStage = workflow.builds.filter(b => _.includes(s.jobs, b.jobName));

--- a/test/handlers/event/push/workflow/CircleWorkflowTest.ts
+++ b/test/handlers/event/push/workflow/CircleWorkflowTest.ts
@@ -301,4 +301,49 @@ describe("CircleWorkflow", () => {
         assert.deepEqual(stages, expectedStages);
     });
 
+    it("should handle workflow config with unused stages", () => {
+        const workflow = {
+            id: "workflow id",
+            name: "pipelineDooling",
+            provider: "circle",
+            config: `workflows:
+  version: 2
+  cd_pipeline:
+    jobs:
+      - build
+      - valid:
+          requires:
+            - build
+      - invalid:
+          requires:
+            - dne
+`,
+            builds: [
+                {
+                    id: "build id 1",
+                    status: "passed",
+                    buildUrl: "buildUrl1",
+                    startedAt: "2017-10-30T17:38:31.564Z",
+                    finishedAt: "2017-10-30T17:38:33.516Z",
+                    jobName: "build",
+                    jobId: "job id 1",
+                },
+            ],
+        } as graphql.PushToPushLifecycle.Workflow;
+        const stages = circleWorkflowtoStages(workflow);
+        const expectedStages: WorkflowStage[] = [
+            {
+                name: "build",
+                completed: {
+                    status: "passed",
+                    totalDuration: 1952,
+                    longestJobDuration: 1952,
+                },
+            }, {
+                name: "valid",
+            },
+        ];
+        assert.deepEqual(stages, expectedStages);
+    });
+
 });


### PR DESCRIPTION
I'm not sure what exactly was causing it to fail for a client in prod, because I haven't seen their config. But after reviewing the code, this seems like the most likely problem that would cause it. I added a test that did loop forever because of an extra stage that did not belong in the workflow. The conditional logic is not more robust in that it will stop trying to order the stages once it goes through the loop and finds none to add to the list (rather than insisting that the count of stages that it will run is equal to the total count of stages).