### PR TITLE
The part about days doesn't apply to 'search issues', it was confusing

### DIFF
--- a/src/handlers/command/github/ListMyGitHubIssues.ts
+++ b/src/handlers/command/github/ListMyGitHubIssues.ts
@@ -83,7 +83,7 @@ export class ListMyGitHubIssues implements HandleCommand {
         if (result && result.data && result.data.items && result.data.items.length > 0) {
             return this.renderIssues(result.data.items, this.apiUrl);
         } else {
-            return `No issues/pull requests found for the last ${this.days} ${this.days > 1 ? "days" : "day"}`;
+            return `No issues/pull requests found`;
         }
     }
 


### PR DESCRIPTION
me: @atomist search issues q="is:open editor"

atomist: No issues/pull requests found for the last 1 day

me: for the last day?