### PR TITLE
support for Circle workflow filtering

### DIFF
--- a/src/handlers/event/push/workflow/CircleWorkflow.ts
+++ b/src/handlers/event/push/workflow/CircleWorkflow.ts
@@ -3,19 +3,19 @@ import * as _ from "lodash";
 import * as graphql from "../../../../typings/types";
 import { WorkflowStage } from "./WorkflowStage";
 
-export interface Push {
+export interface PushTrigger {
     name: string;
     type: PushType;
 }
 
-export type PushType = "branch" | "tag"
+export type PushType = "branch" | "tag";
 
 function findMatchingRegex(text: string, regexes: string[]): string {
-    return regexes.find(r => new RegExp(r.replace(new RegExp('^/(.*?)/'), '$1')).test(text));
+    return regexes.find(r => new RegExp(r.replace(new RegExp("^/(.*?)/"), "$1")).test(text));
 }
 
 export function circleWorkflowtoStages(workflow: graphql.PushToPushLifecycle.Workflow,
-                                       workflowPush: Push = {name: "master", type: "branch"}): WorkflowStage[] {
+                                       workflowPush: PushTrigger = {name: "master", type: "branch"}): WorkflowStage[] {
 
     const doc = yaml.load(workflow.config);
     const jobsConfig = _.find(_.values(doc.workflows), v => v.jobs).jobs;
@@ -31,7 +31,8 @@ export function circleWorkflowtoStages(workflow: graphql.PushToPushLifecycle.Wor
             const filtersBranchesOnly = filtersBranches.only ? filtersBranches.only : [];
             const onlyBranches = typeof filtersBranchesOnly === "string" ? [filtersBranchesOnly] : filtersBranchesOnly;
             const filtersBranchesIgnore = filtersBranches.ignore ? filtersBranches.ignore : [];
-            const ignoreBranches = typeof filtersBranchesIgnore === "string" ? [filtersBranchesIgnore] : filtersBranchesIgnore;
+            const ignoreBranches = typeof filtersBranchesIgnore === "string" ?
+                [filtersBranchesIgnore] : filtersBranchesIgnore;
             const ignoreMatch = findMatchingRegex(workflowPush.name, ignoreBranches);
             if (ignoreMatch) {
                 filtered = true;

--- a/src/handlers/event/push/workflow/CircleWorkflow.ts
+++ b/src/handlers/event/push/workflow/CircleWorkflow.ts
@@ -3,23 +3,79 @@ import * as _ from "lodash";
 import * as graphql from "../../../../typings/types";
 import { WorkflowStage } from "./WorkflowStage";
 
-export function circleWorkflowtoStages(workflow: graphql.PushToPushLifecycle.Workflow): WorkflowStage[] {
+export interface Push {
+    name: string;
+    type: PushType;
+}
+
+export type PushType = "branch" | "tag"
+
+function findMatchingRegex(text: string, regexes: string[]): string {
+    return regexes.find(r => new RegExp(r.replace(new RegExp('^/(.*?)/'), '$1')).test(text));
+}
+
+export function circleWorkflowtoStages(workflow: graphql.PushToPushLifecycle.Workflow,
+                                       workflowPush: Push = {name: "master", type: "branch"}): WorkflowStage[] {
 
     const doc = yaml.load(workflow.config);
     const jobsConfig = _.find(_.values(doc.workflows), v => v.jobs).jobs;
     const stages: Stage[] = [];
     jobsConfig.forEach(jc => {
         const name = typeof jc === "string" ? jc : _.head(_.keys(jc));
-        const requires = typeof jc === "string" ? [] : jc[name].requires;
-        let stage = _.find(stages, j => _.isEqual(j.require, requires));
-        if (!stage) {
-            stage = {
-                jobs: [name],
-                require: requires,
-            };
-            stages.push(stage);
-        } else {
-            stage.jobs.push(name);
+        const jobConfig = !jc[name] ? {} : jc[name];
+
+        let filtered = false;
+        const filters = jobConfig.filters ? jobConfig.filters : {};
+        if (workflowPush.type === "branch") {
+            const filtersBranches = filters.branches ? filters.branches : {};
+            const filtersBranchesOnly = filtersBranches.only ? filtersBranches.only : [];
+            const onlyBranches = typeof filtersBranchesOnly === "string" ? [filtersBranchesOnly] : filtersBranchesOnly;
+            const filtersBranchesIgnore = filtersBranches.ignore ? filtersBranches.ignore : [];
+            const ignoreBranches = typeof filtersBranchesIgnore === "string" ? [filtersBranchesIgnore] : filtersBranchesIgnore;
+            const ignoreMatch = findMatchingRegex(workflowPush.name, ignoreBranches);
+            if (ignoreMatch) {
+                filtered = true;
+            } else {
+                if (onlyBranches.length > 0) {
+                    filtered = true;
+                    if (!!findMatchingRegex(workflowPush.name, onlyBranches)) {
+                        filtered = false;
+                    }
+                }
+            }
+        }
+        if (workflowPush.type === "tag") {
+            const filtersTags = filters.tags ? filters.tags : {};
+            const filtersTagsOnly = filtersTags.only ? filtersTags.only : [];
+            const onlyTags = typeof filtersTagsOnly === "string" ? [filtersTagsOnly] : filtersTagsOnly;
+            const filtersTagsIgnore = filtersTags.ignore ? filtersTags.ignore : [];
+            const ignoreTags = typeof filtersTagsIgnore === "string" ? [filtersTagsIgnore] : filtersTagsIgnore;
+            filtered = !(ignoreTags.length > 0);
+            const ignoreMatch = findMatchingRegex(workflowPush.name, ignoreTags);
+            if (ignoreMatch) {
+                filtered = true;
+            } else {
+                if (onlyTags.length > 0) {
+                    filtered = true;
+                    if (!!findMatchingRegex(workflowPush.name, onlyTags)) {
+                        filtered = false;
+                    }
+                }
+            }
+        }
+
+        if (!filtered) {
+            const requires = !jobConfig.requires ? [] : jobConfig.requires;
+            let stage = _.find(stages, j => _.isEqual(j.require, requires));
+            if (!stage) {
+                stage = {
+                    jobs: [name],
+                    require: requires,
+                };
+                stages.push(stage);
+            } else {
+                stage.jobs.push(name);
+            }
         }
     });
 

--- a/src/handlers/event/push/workflow/WorkflowNodeRenderer.ts
+++ b/src/handlers/event/push/workflow/WorkflowNodeRenderer.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../lifecycle/Lifecycle";
 import * as graphql from "../../../../typings/types";
 import { chartUrlFromWorkflow } from "./ChartUrl";
-import { circleWorkflowtoStages } from "./CircleWorkflow";
+import {circleWorkflowtoStages, PushTrigger} from "./CircleWorkflow";
 
 export class WorkflowNodeRenderer extends AbstractIdentifiableContribution
     implements NodeRenderer<graphql.PushToPushLifecycle.Builds> {
@@ -24,7 +24,12 @@ export class WorkflowNodeRenderer extends AbstractIdentifiableContribution
 
     public render(workflow: graphql.PushToPushLifecycle.Workflow, actions: Action[], msg: SlackMessage,
                   context: RendererContext): Promise<SlackMessage> {
-        const chartUrl = chartUrlFromWorkflow(circleWorkflowtoStages(workflow));
+        const push = context.lifecycle.extract("push") as graphql.PushToPushLifecycle.Push;
+        const pushTrigger: PushTrigger = {
+            name: push.branch,
+            type: "branch", // we only trigger on branch pushes currently, though the logic here would handle tags
+        };
+        const chartUrl = chartUrlFromWorkflow(circleWorkflowtoStages(workflow, pushTrigger));
         if (chartUrl) {
             const attachment: Attachment = {
                 author_name: "Workflow",

--- a/test/handlers/event/push/workflow/CircleWorkflowTest.ts
+++ b/test/handlers/event/push/workflow/CircleWorkflowTest.ts
@@ -752,7 +752,6 @@ describe("CircleWorkflow", () => {
         assert.deepEqual(stages, expectedStages);
     });
 
-
     const branchAndTagFiltersWorkflow2 = {
         id: "workflow id",
         name: "pipelineDooling",


### PR DESCRIPTION
This won't compile yet and should not be merged. I don't know where to get the branch or tag name that is needed to filter on.
There is added logic to filter jobs based on the branch and filter portion of the workflow config. The tests show that the logic works. You can see that circleWorkflowtoStages() now takes a Push object.
```
export interface Push {
    name: string;
    type: PushType;
}

export type PushType = "branch" | "tag"
```
I don't know where in our model to get this information about the push that started the workflow.

It is confusing because a Workflow object has _Builds but Builds also exists. And _Builds doesn't have the info that I need.