### PR TITLE
Don't fail when msgId is null

### DIFF
--- a/src/handlers/command/slack/AssociateRepo.ts
+++ b/src/handlers/command/slack/AssociateRepo.ts
@@ -105,10 +105,12 @@ export class AssociateRepo implements HandleCommand {
                     })
                     .then(() => inviteUserToSlackChannel(ctx, this.channelId, this.userId))
                     .then(() => {
+                        const msg = `Linked ${slack.bold(this.owner + "/" + this.repo)} to ` +
+                            `${slack.channel(this.channelId)} and invited you to the channel.`;
                         if (this.msgId) {
-                            const msg = `Linked ${slack.bold(this.owner + "/" + this.repo)} to ` +
-                                `${slack.channel(this.channelId)} and invited you to the channel.`;
                             ctx.messageClient.addressUsers(msg, screenName, { id: this.msgId });
+                        } else {
+                            ctx.messageClient.respond(msg);
                         }
                         return Success;
                     });

--- a/src/handlers/event/push/PushToUnmappedRepo.ts
+++ b/src/handlers/event/push/PushToUnmappedRepo.ts
@@ -105,7 +105,7 @@ export function mapRepoMessageId(owner: string, repo: string, screenName: string
  * @return screen name
  */
 export function extractScreenNameFromMapRepoMessageId(msgId: string): string {
-    return msgId.split("/")[2];
+    return msgId ? msgId.split("/")[2] : null;
 }
 
 function getDisabledRepos(preferences: graphql.PushToUnmappedRepo._Preferences[]): string[] {

--- a/test/handlers/event/push/PushToUnmappedRepoTest.ts
+++ b/test/handlers/event/push/PushToUnmappedRepoTest.ts
@@ -96,6 +96,10 @@ describe("PushToUnmappedRepo", () => {
             assert(extractScreenNameFromMapRepoMessageId(mapRepoMessageId(owner, repo, screenName)) === screenName);
         });
 
+        it("should return null for a null message ID", () => {
+            assert(extractScreenNameFromMapRepoMessageId(null) === null);
+        });
+
     });
 
     describe("mapRepoMessage", () => {


### PR DESCRIPTION

When command is run as a command handler it won't have
msgId populated. We should handle null msgId without failing
the command