### PR TITLE
update subscriptions to match new K8 attributes

### DIFF
--- a/graphql/subscription/applicationToPush.graphql
+++ b/graphql/subscription/applicationToPush.graphql
@@ -114,11 +114,11 @@ subscription ApplicationToPushLifecycle
                         }
                         containers {
                             pods {
-                                host
-                                state
+                                baseName
+                                phase
                                 name
                             }
-                            image
+                            imageName
                         }
                     }
                     author {

--- a/graphql/subscription/applicationToPush.graphql
+++ b/graphql/subscription/applicationToPush.graphql
@@ -112,14 +112,14 @@ subscription ApplicationToPushLifecycle
                         release {
                             name
                         }
-                        containers {
-                            pods {
-                                baseName
-                                phase
-                                name
-                            }
-                            imageName
+                    }
+                    image {
+                        pods {
+                            baseName
+                            phase
+                            name
                         }
+                        imageName
                     }
                     author {
                         login

--- a/graphql/subscription/buildToPush.graphql
+++ b/graphql/subscription/buildToPush.graphql
@@ -111,14 +111,14 @@ subscription BuildToPushLifecycle
                     release {
                         name
                     }
-                    containers {
-                        pods {
-                            baseName
-                            phase
-                            name
-                        }
-                        imageName
+                }
+                image {
+                    pods {
+                        baseName
+                        phase
+                        name
                     }
+                    imageName
                 }
                 author {
                     login

--- a/graphql/subscription/buildToPush.graphql
+++ b/graphql/subscription/buildToPush.graphql
@@ -113,11 +113,11 @@ subscription BuildToPushLifecycle
                     }
                     containers {
                         pods {
-                            host
-                            state
+                            baseName
+                            phase
                             name
                         }
-                        image
+                        imageName
                     }
                 }
                 author {

--- a/graphql/subscription/issueToPush.graphql
+++ b/graphql/subscription/issueToPush.graphql
@@ -112,14 +112,14 @@ subscription IssueToPushLifecycle
                         release {
                             name
                         }
-                        containers {
-                            pods {
-                                baseName
-                                phase
-                                name
-                            }
-                            imageName
+                    }
+                    image {
+                        pods {
+                            baseName
+                            phase
+                            name
                         }
+                        imageName
                     }
                     author {
                         login

--- a/graphql/subscription/issueToPush.graphql
+++ b/graphql/subscription/issueToPush.graphql
@@ -114,11 +114,11 @@ subscription IssueToPushLifecycle
                         }
                         containers {
                             pods {
-                                host
-                                state
+                                baseName
+                                phase
                                 name
                             }
-                            image
+                            imageName
                         }
                     }
                     author {

--- a/graphql/subscription/k8podToPush.graphql
+++ b/graphql/subscription/k8podToPush.graphql
@@ -118,11 +118,11 @@ subscription K8PodToPushLifecycle
                                 }
                                 containers {
                                     pods {
-                                        host
-                                        state
+                                        baseName
+                                        phase
                                         name
                                     }
-                                    image
+                                    imageName
                                 }
                             }
                             author {

--- a/graphql/subscription/k8podToPush.graphql
+++ b/graphql/subscription/k8podToPush.graphql
@@ -1,148 +1,145 @@
-subscription K8PodToPushLifecycle
-{
+subscription K8PodToPushLifecycle {
     K8Pod {
         _id
         name
         state
         images {
-            tag {
-                commit {
-                    pushes {
-                        builds {
-                            id
-                            buildUrl
-                            name
-                            provider
-                            status
-                            commit {
-                                sha
-                            }
-                            timestamp
-                            workflow {
-                                id
-                                name
-                                provider
-                                config
-                                builds {
-                                    jobId
-                                    jobName
-                                    finishedAt
-                                    startedAt
-                                    status
-                                    id
-                                    buildUrl
-                                }
-                            }
-                        }
-                        before {
+            commits {
+                pushes {
+                    builds {
+                        id
+                        buildUrl
+                        name
+                        provider
+                        status
+                        commit {
                             sha
-                        }
-                        after {
-                            sha
-                            message
-                            statuses {
-                                context
-                                description
-                                targetUrl
-                                state
-                            }
-                            tags {
-                                name
-                                release {
-                                    name
-                                }
-                                builds {
-                                    buildId
-                                    buildUrl
-                                    name
-                                    provider
-                                    status
-                                    timestamp
-                                }
-                            }
-                        }
-                        repo {
-                            owner
-                            name
-                            channels {
-                                name
-                                team {
-                                    id
-                                }
-                            }
-                            labels {
-                                name
-                            }
-                            org {
-                                provider {
-                                    url
-                                    apiUrl
-                                    gitUrl
-                                }
-                                team {
-                                    id
-                                    chatTeams {
-                                        id
-                                        preferences {
-                                            name
-                                            value
-                                        }
-                                    }
-                                }
-                            }
-                            defaultBranch
-                        }
-                        commits {
-                            sha
-                            message
-                            resolves {
-                                number
-                                name
-                                title
-                                state
-                            }
-                            impact {
-                                data
-                                url
-                            }
-                            apps {
-                                state
-                                host
-                                domain
-                                data
-                            }
-                            tags {
-                                name
-                                release {
-                                    name
-                                }
-                            }
-                            image {
-                                pods {
-                                    baseName
-                                    phase
-                                    name
-                                }
-                                imageName
-                            }
-                            author {
-                                login
-                                person {
-                                    chatId {
-                                        screenName
-                                    }
-                                }
-                            }
-                            timestamp
                         }
                         timestamp
-                        branch
+                        workflow {
+                            id
+                            name
+                            provider
+                            config
+                            builds {
+                                jobId
+                                jobName
+                                finishedAt
+                                startedAt
+                                status
+                                id
+                                buildUrl
+                            }
+                        }
+                    }
+                    before {
+                        sha
+                    }
+                    after {
+                        sha
+                        message
+                        statuses {
+                            context
+                            description
+                            targetUrl
+                            state
+                        }
+                        tags {
+                            name
+                            release {
+                                name
+                            }
+                            builds {
+                                buildId
+                                buildUrl
+                                name
+                                provider
+                                status
+                                timestamp
+                            }
+                        }
+                    }
+                    repo {
+                        owner
+                        name
+                        channels {
+                            name
+                            team {
+                                id
+                            }
+                        }
+                        labels {
+                            name
+                        }
+                        org {
+                            provider {
+                                url
+                                apiUrl
+                                gitUrl
+                            }
+                            team {
+                                id
+                                chatTeams {
+                                    id
+                                    preferences {
+                                        name
+                                        value
+                                    }
+                                }
+                            }
+                        }
+                        defaultBranch
+                    }
+                    commits {
+                        sha
+                        message
+                        resolves {
+                            number
+                            name
+                            title
+                            state
+                        }
+                        impact {
+                            data
+                            url
+                        }
+                        apps {
+                            state
+                            host
+                            domain
+                            data
+                        }
+                        tags {
+                            name
+                            release {
+                                name
+                            }
+                        }
+                        image {
+                            pods {
+                                baseName
+                                phase
+                                name
+                            }
+                            imageName
+                        }
+                        author {
+                            login
+                            person {
+                                chatId {
+                                    screenName
+                                }
+                            }
+                        }
+                        timestamp
                     }
                     timestamp
+                    branch
                 }
                 timestamp
             }
+            timestamp
         }
-        timestamp
     }
 }
+

--- a/graphql/subscription/k8podToPush.graphql
+++ b/graphql/subscription/k8podToPush.graphql
@@ -116,14 +116,14 @@ subscription K8PodToPushLifecycle
                                 release {
                                     name
                                 }
-                                containers {
-                                    pods {
-                                        baseName
-                                        phase
-                                        name
-                                    }
-                                    imageName
+                            }
+                            image {
+                                pods {
+                                    baseName
+                                    phase
+                                    name
                                 }
+                                imageName
                             }
                             author {
                                 login

--- a/graphql/subscription/parentimpactToPush.graphql
+++ b/graphql/subscription/parentimpactToPush.graphql
@@ -114,11 +114,11 @@ subscription ParentImpactToPushLifecycle
                         }
                         containers {
                             pods {
-                                host
-                                state
+                                baseName
+                                phase
                                 name
                             }
-                            image
+                            imageName
                         }
                     }
                     author {

--- a/graphql/subscription/parentimpactToPush.graphql
+++ b/graphql/subscription/parentimpactToPush.graphql
@@ -112,14 +112,14 @@ subscription ParentImpactToPushLifecycle
                         release {
                             name
                         }
-                        containers {
-                            pods {
-                                baseName
-                                phase
-                                name
-                            }
-                            imageName
+                    }
+                    image {
+                        pods {
+                            baseName
+                            phase
+                            name
                         }
+                        imageName
                     }
                     author {
                         login

--- a/graphql/subscription/pushToPush.graphql
+++ b/graphql/subscription/pushToPush.graphql
@@ -112,11 +112,11 @@ subscription PushToPushLifecycle
                 }
                 containers {
                     pods {
-                        host
-                        state
+                        baseName
+                        phase
                         name
                     }
-                    image
+                    imageName
                 }
             }
             author {

--- a/graphql/subscription/pushToPush.graphql
+++ b/graphql/subscription/pushToPush.graphql
@@ -110,14 +110,14 @@ subscription PushToPushLifecycle
                 release {
                     name
                 }
-                containers {
-                    pods {
-                        baseName
-                        phase
-                        name
-                    }
-                    imageName
+            }
+            image {
+                pods {
+                    baseName
+                    phase
+                    name
                 }
+                imageName
             }
             author {
                 login

--- a/graphql/subscription/releaseToPush.graphql
+++ b/graphql/subscription/releaseToPush.graphql
@@ -113,14 +113,14 @@ subscription ReleaseToPushLifecycle
                             release {
                                 name
                             }
-                            containers {
-                                pods {
-                                    baseName
-                                    phase
-                                    name
-                                }
-                                imageName
+                        }
+                        image {
+                            pods {
+                                baseName
+                                phase
+                                name
                             }
+                            imageName
                         }
                         author {
                             login

--- a/graphql/subscription/releaseToPush.graphql
+++ b/graphql/subscription/releaseToPush.graphql
@@ -115,11 +115,11 @@ subscription ReleaseToPushLifecycle
                             }
                             containers {
                                 pods {
-                                    host
-                                    state
+                                    baseName
+                                    phase
                                     name
                                 }
-                                image
+                                imageName
                             }
                         }
                         author {

--- a/graphql/subscription/statusToPush.graphql
+++ b/graphql/subscription/statusToPush.graphql
@@ -112,14 +112,14 @@ subscription StatusToPushLifecycle
                         release {
                             name
                         }
-                        containers {
-                            pods {
-                                baseName
-                                phase
-                                name
-                            }
-                            imageName
+                    }
+                    image {
+                        pods {
+                            baseName
+                            phase
+                            name
                         }
+                        imageName
                     }
                     author {
                         login

--- a/graphql/subscription/statusToPush.graphql
+++ b/graphql/subscription/statusToPush.graphql
@@ -114,11 +114,11 @@ subscription StatusToPushLifecycle
                         }
                         containers {
                             pods {
-                                host
-                                state
+                                baseName
+                                phase
                                 name
                             }
-                            image
+                            imageName
                         }
                     }
                     author {

--- a/graphql/subscription/tagToPush.graphql
+++ b/graphql/subscription/tagToPush.graphql
@@ -112,14 +112,14 @@ subscription TagToPushLifecycle
                         release {
                             name
                         }
-                        containers {
-                            pods {
-                                baseName
-                                phase
-                                name
-                            }
-                            imageName
+                    }
+                    image {
+                        pods {
+                            baseName
+                            phase
+                            name
                         }
+                        imageName
                     }
                     author {
                         login

--- a/graphql/subscription/tagToPush.graphql
+++ b/graphql/subscription/tagToPush.graphql
@@ -114,11 +114,11 @@ subscription TagToPushLifecycle
                         }
                         containers {
                             pods {
-                                host
-                                state
+                                baseName
+                                phase
                                 name
                             }
-                            image
+                            imageName
                         }
                     }
                     author {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@atomist/automation-client": {
       "version": "https://r.atomist.com/Bk1eNArMBNG",
-      "integrity": "sha1-xYJnLkoE/WAs5otbVheu17A72p0=",
+      "integrity": "sha512-bXG6B/tMtyRk8EoRaZuZO8sj+nSmv5FoZ+hH2yheSWk+LCNAvhhFgNzyfLPbx4WrfVGWBtCxytPFWDXS5cr+ow==",
       "requires": {
         "@atomist/microgrammar": "0.7.0",
         "@atomist/slack-messages": "0.12.1",
@@ -65,25 +65,6 @@
         "winston": "2.4.0",
         "ws": "4.0.0",
         "yargs": "10.1.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix-20180111160124.tgz",
-          "integrity": "sha1-2+5dTf3FzEvXoIgtL5/3hxmYCjQ=",
-          "requires": {
-            "follow-redirects": "1.3.0",
-            "is-buffer": "1.1.6",
-            "tunnel-agent": "0.6.0"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "@atomist/microgrammar": {
@@ -139,7 +120,7 @@
       "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
       "dev": true,
       "requires": {
-        "commander": "2.12.2"
+        "commander": "2.13.0"
       }
     },
     "@types/config": {
@@ -520,14 +501,14 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-exit-hook": {
       "version": "2.0.1",
@@ -554,9 +535,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.6.0",
@@ -565,21 +546,11 @@
     },
     "axios": {
       "version": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix-20180111160124.tgz",
-      "integrity": "sha1-2+5dTf3FzEvXoIgtL5/3hxmYCjQ=",
+      "integrity": "sha512-9o1726RIVOxoNWHOR+j0Brz13Xx3r4DN9mIhckV0NRYjgb0L/182TftOVG6zsklMJCjI51jnhzpOB6SP2ksS4A==",
       "requires": {
         "follow-redirects": "1.3.0",
         "is-buffer": "1.1.6",
         "tunnel-agent": "0.6.0"
-      },
-      "dependencies": {
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "babel-code-frame": {
@@ -729,11 +700,11 @@
       }
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "brace-expansion": {
@@ -789,9 +760,10 @@
       }
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "optional": true
     },
     "camelize": {
       "version": "1.0.0",
@@ -799,9 +771,9 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
@@ -823,10 +795,186 @@
         "restler": "3.4.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
         "bluebird": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.6.tgz",
           "integrity": "sha1-8kiPMleC9m0XSEL0gZkuL6ulbzg="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "form-data": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "requires": {
+            "async": "2.6.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.13.0",
+            "is-my-json-valid": "2.17.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "qs": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
+          "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw="
+        },
+        "request": {
+          "version": "2.67.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+          "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "bl": "1.0.3",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.1",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "5.2.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.2",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "tough-cookie": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+          "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc="
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
@@ -915,13 +1063,22 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-      "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "optional": true,
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "optional": true
+        }
       }
     },
     "clone": {
@@ -966,9 +1123,9 @@
       }
     },
     "commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
     },
     "commandpost": {
       "version": "1.2.1",
@@ -977,9 +1134,9 @@
       "dev": true
     },
     "common-tags": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.0.tgz",
-      "integrity": "sha512-A63PFbYd8ccyVZbqZkWjQ9+BqSaROt/BCNesdhZZNjvUXx1U59fA+XDeaIJWqrgPsoIdmYds1qofDNDvrffw9Q==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
+      "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -1098,11 +1255,21 @@
       }
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "cycle": {
@@ -1125,13 +1292,6 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "dasherize": {
@@ -1249,11 +1409,11 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
@@ -1281,7 +1441,7 @@
       "requires": {
         "@types/commander": "2.12.2",
         "@types/semver": "5.4.0",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "lru-cache": "4.1.1",
         "semver": "5.4.1",
         "sigmund": "1.0.1"
@@ -1341,9 +1501,9 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "1.4.0"
       }
@@ -1507,6 +1667,13 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1538,6 +1705,14 @@
         "source-map": "0.5.7",
         "type-name": "2.0.2",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "espower-location-detector": {
@@ -1550,6 +1725,14 @@
         "path-is-absolute": "1.0.1",
         "source-map": "0.5.7",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "espower-source": {
@@ -1874,23 +2057,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-      "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "async": "2.6.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        }
       }
     },
     "format-date": {
@@ -1975,13 +2148,6 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "github": {
@@ -2035,7 +2201,7 @@
         "glob-parent": "3.1.0",
         "is-negated-glob": "1.0.0",
         "ordered-read-streams": "1.0.1",
-        "pumpify": "1.3.5",
+        "pumpify": "1.3.6",
         "readable-stream": "2.3.3",
         "remove-trailing-separator": "1.1.0",
         "to-absolute-glob": "2.0.2",
@@ -2068,154 +2234,13 @@
       "resolved": "https://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.8.14.tgz",
       "integrity": "sha512-5MoX1Mi1fgVWfp6ppvYOmINRNge52booCjXJPAeKjQNhS1tu3Egc9j6lXjjMVDlt9z+A7ouc7TjYYtosgSjFig==",
       "requires": {
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "glob": "7.1.2",
         "graphql-codegen-compiler": "0.8.14",
         "graphql-codegen-core": "0.8.14",
         "graphql-codegen-generators": "0.8.14",
         "mkdirp": "0.5.1",
         "request": "2.83.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "graphql-codegen-compiler": {
@@ -2225,7 +2250,7 @@
       "requires": {
         "@types/handlebars": "4.0.36",
         "change-case": "3.0.1",
-        "common-tags": "1.7.0",
+        "common-tags": "1.7.2",
         "graphql-codegen-compiler": "0.8.14",
         "graphql-codegen-core": "0.8.14",
         "graphql-codegen-generators": "0.8.14",
@@ -2284,21 +2309,6 @@
         "optimist": "0.6.1",
         "source-map": "0.4.4",
         "uglify-js": "2.8.29"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
       }
     },
     "har-schema": {
@@ -2307,51 +2317,12 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.12.2",
-        "is-my-json-valid": "2.17.1",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -2384,14 +2355,14 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -2457,9 +2428,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -2503,11 +2474,11 @@
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "0.2.0",
+        "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
@@ -2862,13 +2833,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "kind-of": {
@@ -2953,147 +2917,6 @@
         "lodash.assign": "4.2.0",
         "moment": "2.20.1",
         "request": "2.83.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "longest": {
@@ -3227,9 +3050,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -3237,6 +3060,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "mocha": {
@@ -3495,15 +3325,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.8",
+        "minimist": "0.0.10",
         "wordwrap": "0.0.3"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-        }
       }
     },
     "optionator": {
@@ -3518,6 +3341,14 @@
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2",
         "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
       }
     },
     "ordered-read-streams": {
@@ -3928,22 +3759,22 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
+      "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
       }
     },
     "pumpify": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.6.tgz",
+      "integrity": "sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==",
       "requires": {
-        "duplexify": "3.5.1",
+        "duplexify": "3.5.3",
         "inherits": "2.0.3",
-        "pump": "1.0.3"
+        "pump": "2.0.0"
       }
     },
     "punycode": {
@@ -4031,42 +3862,32 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
-      "version": "2.67.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-      "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.6.0",
-        "bl": "1.0.3",
-        "caseless": "0.11.0",
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
         "combined-stream": "1.0.5",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "1.0.1",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.17",
-        "node-uuid": "1.4.8",
         "oauth-sign": "0.8.2",
-        "qs": "5.2.1",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.2.2",
-        "tunnel-agent": "0.4.3"
-      },
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "qs": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
-          "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw="
-        }
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
       }
     },
     "require-directory": {
@@ -4321,17 +4142,20 @@
       }
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "source-map-support": {
       "version": "0.5.0",
@@ -4398,13 +4222,6 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "stack-trace": {
@@ -4626,9 +4443,12 @@
       }
     },
     "tough-cookie": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-      "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "traverse": {
       "version": "0.6.6",
@@ -4680,17 +4500,18 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
-      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
         "chalk": "2.3.0",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "diff": "3.3.1",
         "glob": "7.1.2",
+        "js-yaml": "3.10.0",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
@@ -4708,9 +4529,12 @@
       }
     },
     "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -4839,27 +4663,10 @@
         "yargs": "3.10.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "optional": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "optional": true
         },
         "yargs": {
@@ -5019,13 +4826,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
       }
     },
     "whatwg-fetch": {
@@ -5063,6 +4863,13 @@
         "eyes": "0.1.8",
         "isstream": "0.1.2",
         "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        }
       }
     },
     "winston-logzio": {
@@ -5077,6 +4884,11 @@
         "winston": "1.0.2"
       },
       "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
         "winston": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/winston/-/winston-1.0.2.tgz",
@@ -5094,10 +4906,9 @@
       }
     },
     "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -5212,6 +5023,18 @@
         "which-module": "2.0.0",
         "y18n": "3.2.1",
         "yargs-parser": "8.1.0"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        }
       }
     },
     "yargs-parser": {
@@ -5220,6 +5043,13 @@
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "requires": {
         "camelcase": "4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        }
       }
     },
     "yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "dependencies": {
     "@atomist/automation-client": {
-      "version": "https://r.atomist.com/Skwgq6C_QNf",
-      "integrity": "sha512-XhBQG2KwzbLJis5IIEAMWOzhUB32SyzJGlDY2/zMtO0xAinmETSPkLS4rmZULVknIP013200HG+fUlqPe6t8Qg==",
+      "version": "https://r.atomist.com/Bk1eNArMBNG",
+      "integrity": "sha1-xYJnLkoE/WAs5otbVheu17A72p0=",
       "requires": {
         "@atomist/microgrammar": "0.7.0",
         "@atomist/slack-messages": "0.12.1",
@@ -23,7 +23,7 @@
         "apollo-link-http": "1.3.2",
         "app-root-path": "2.0.1",
         "async-exit-hook": "2.0.1",
-        "axios": "0.17.1",
+        "axios": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix-20180111160124.tgz",
         "base-64": "0.1.0",
         "body-parser": "1.18.2",
         "child-process-promise": "2.2.1",
@@ -34,10 +34,13 @@
         "express-session": "1.15.6",
         "fs-extra": "5.0.0",
         "github": "13.1.0",
+        "glob-promise": "3.3.0",
         "glob-stream": "6.1.0",
         "graphql": "0.12.3",
+        "graphql-code-generator": "0.8.14",
         "graphql-tag": "2.6.1",
         "helmet": "3.9.0",
+        "https-proxy-agent": "2.1.1",
         "inquirer": "4.0.2",
         "isbinaryfile": "3.0.2",
         "isomorphic-fetch": "2.2.1",
@@ -62,6 +65,25 @@
         "winston": "2.4.0",
         "ws": "4.0.0",
         "yargs": "10.1.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix-20180111160124.tgz",
+          "integrity": "sha1-2+5dTf3FzEvXoIgtL5/3hxmYCjQ=",
+          "requires": {
+            "follow-redirects": "1.3.0",
+            "is-buffer": "1.1.6",
+            "tunnel-agent": "0.6.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
     "@atomist/microgrammar": {
@@ -183,8 +205,7 @@
     "@types/handlebars": {
       "version": "4.0.36",
       "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
-      "integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==",
-      "dev": true
+      "integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ=="
     },
     "@types/helmet": {
       "version": "0.0.37",
@@ -341,7 +362,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -351,8 +371,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "3.0.0",
@@ -545,12 +564,22 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "version": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix-20180111160124.tgz",
+      "integrity": "sha1-2+5dTf3FzEvXoIgtL5/3hxmYCjQ=",
       "requires": {
         "follow-redirects": "1.3.0",
-        "is-buffer": "1.1.6"
+        "is-buffer": "1.1.6",
+        "tunnel-agent": "0.6.0"
+      },
+      "dependencies": {
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
     "babel-code-frame": {
@@ -610,7 +639,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
@@ -755,7 +783,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2",
         "upper-case": "1.1.3"
@@ -780,7 +807,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -839,7 +865,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.1.tgz",
       "integrity": "sha1-7l9a0EFa0a2egHLPSc1M+nZgpVQ=",
-      "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "constant-case": "2.0.0",
@@ -955,7 +980,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.0.tgz",
       "integrity": "sha512-A63PFbYd8ccyVZbqZkWjQ9+BqSaROt/BCNesdhZZNjvUXx1U59fA+XDeaIJWqrgPsoIdmYds1qofDNDvrffw9Q==",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -978,7 +1002,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
-      "dev": true,
       "requires": {
         "snake-case": "2.1.0",
         "upper-case": "1.1.3"
@@ -1210,7 +1233,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2"
       }
@@ -1998,6 +2020,11 @@
         "path-dirname": "1.0.2"
       }
     },
+    "glob-promise": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.3.0.tgz",
+      "integrity": "sha512-X5VIEO/yy5NH3p9ORhlNodakQo/cK4I0lCtARNeAkWueJiToew5Xs9DiukVKsW5dgpjnnQgou9Rbj3HUkM6OUw=="
+    },
     "glob-stream": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
@@ -2040,7 +2067,6 @@
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.8.14.tgz",
       "integrity": "sha512-5MoX1Mi1fgVWfp6ppvYOmINRNge52booCjXJPAeKjQNhS1tu3Egc9j6lXjjMVDlt9z+A7ouc7TjYYtosgSjFig==",
-      "dev": true,
       "requires": {
         "commander": "2.12.2",
         "glob": "7.1.2",
@@ -2054,20 +2080,17 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "aws-sign2": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-          "dev": true
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "boom": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true,
           "requires": {
             "hoek": "4.2.0"
           }
@@ -2075,14 +2098,12 @@
         "caseless": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "cryptiles": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "dev": true,
           "requires": {
             "boom": "5.2.0"
           },
@@ -2091,7 +2112,6 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true,
               "requires": {
                 "hoek": "4.2.0"
               }
@@ -2102,7 +2122,6 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -2113,7 +2132,6 @@
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
           "requires": {
             "ajv": "5.5.2",
             "har-schema": "2.0.0"
@@ -2123,7 +2141,6 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true,
           "requires": {
             "boom": "4.3.1",
             "cryptiles": "3.1.2",
@@ -2134,14 +2151,12 @@
         "hoek": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-          "dev": true
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
         },
         "http-signature": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "jsprim": "1.4.1",
@@ -2152,7 +2167,6 @@
           "version": "2.83.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "dev": true,
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.6.0",
@@ -2182,7 +2196,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "dev": true,
           "requires": {
             "hoek": "4.2.0"
           }
@@ -2191,7 +2204,6 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -2200,7 +2212,6 @@
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -2211,7 +2222,6 @@
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/graphql-codegen-compiler/-/graphql-codegen-compiler-0.8.14.tgz",
       "integrity": "sha512-eOm82FcEmtu0tfuBIrwItsS5R2sqkZtaj0t0/kJGHIh8PFCOH4NEOVZHliYQ8cgQhicekglKB1P/CdUvzBX2RA==",
-      "dev": true,
       "requires": {
         "@types/handlebars": "4.0.36",
         "change-case": "3.0.1",
@@ -2226,7 +2236,6 @@
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.8.14.tgz",
       "integrity": "sha512-HMQUC8xW/NjT6LQJPXi+oxkEIG42hVqaKN9AMEJFwI5OAJy1oeWQbkYNqVsNAu/oiokr+j8oeZwEQEkpSWNsQw==",
-      "dev": true,
       "requires": {
         "graphql-tag": "2.6.1",
         "graphql-tools": "1.2.3"
@@ -2235,8 +2244,7 @@
     "graphql-codegen-generators": {
       "version": "0.8.14",
       "resolved": "https://registry.npmjs.org/graphql-codegen-generators/-/graphql-codegen-generators-0.8.14.tgz",
-      "integrity": "sha512-QGpKFG0IRiLeHBsuezXpVAISsX7Ov32jZNbnZSgeeNk/ghK0jYheHPsN+SqBta73J/Kp2RJHB+RG/K1tIDHh3g==",
-      "dev": true
+      "integrity": "sha512-QGpKFG0IRiLeHBsuezXpVAISsX7Ov32jZNbnZSgeeNk/ghK0jYheHPsN+SqBta73J/Kp2RJHB+RG/K1tIDHh3g=="
     },
     "graphql-tag": {
       "version": "2.6.1",
@@ -2247,7 +2255,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-1.2.3.tgz",
       "integrity": "sha512-3inNK3rmk32G4hGWbqBuVNxusF+Mcuckg+3aD4hHaMxO0LrSgteWoTD8pTD9GUnmoSRG4AbYHZ0jibGD5MTlrQ==",
-      "dev": true,
       "requires": {
         "@types/graphql": "0.9.4",
         "deprecated-decorator": "0.1.6",
@@ -2258,7 +2265,6 @@
           "version": "0.9.4",
           "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.9.4.tgz",
           "integrity": "sha512-ob2dps4itT/Le5DbxjssBXtBnloDIRUbkgtAvaB42mJ8pVIWMRuURD9WjnhaEGZ4Ql/EryXMQWeU8Y0EU73QLw==",
-          "dev": true,
           "optional": true
         }
       }
@@ -2273,7 +2279,6 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -2284,14 +2289,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -2401,7 +2404,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2",
         "upper-case": "1.1.3"
@@ -2647,7 +2649,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
-      "dev": true,
       "requires": {
         "lower-case": "1.1.4"
       }
@@ -2723,7 +2724,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
-      "dev": true,
       "requires": {
         "upper-case": "1.1.3"
       }
@@ -2875,7 +2875,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
@@ -2884,7 +2883,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "lcid": {
@@ -3101,20 +3099,17 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lower-case-first": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
-      "dev": true,
       "requires": {
         "lower-case": "1.1.4"
       }
@@ -3234,14 +3229,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -3330,7 +3323,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "dev": true,
       "requires": {
         "lower-case": "1.1.4"
       }
@@ -3502,7 +3494,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.3"
@@ -3511,8 +3502,7 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
@@ -3588,7 +3578,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2"
       }
@@ -3618,7 +3607,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
-      "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "upper-case-first": "1.1.2"
@@ -3658,7 +3646,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2"
       }
@@ -4031,8 +4018,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -4042,8 +4028,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
       "version": "2.67.0",
@@ -4143,7 +4128,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -4233,7 +4217,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2",
         "upper-case-first": "1.1.2"
@@ -4333,7 +4316,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2"
       }
@@ -4349,8 +4331,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
       "version": "0.5.0",
@@ -4576,7 +4557,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
-      "dev": true,
       "requires": {
         "lower-case": "1.1.4",
         "upper-case": "1.1.3"
@@ -4614,7 +4594,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
-      "dev": true,
       "requires": {
         "no-case": "2.3.2",
         "upper-case": "1.1.3"
@@ -4853,7 +4832,6 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.7",
@@ -4865,14 +4843,12 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "0.1.3",
@@ -4884,14 +4860,12 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -4906,7 +4880,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "uid-safe": {
@@ -4964,14 +4937,12 @@
     "upper-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-      "dev": true
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "upper-case-first": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "dev": true,
       "requires": {
         "upper-case": "1.1.3"
       }
@@ -5079,7 +5050,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "winston": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "travis-ci"
   ],
   "dependencies": {
-    "@atomist/automation-client": "https://r.atomist.com/Skwgq6C_QNf",
+    "@atomist/automation-client": "https://r.atomist.com/Bk1eNArMBNG",
     "@atomist/slack-messages": "^0.12.1",
     "app-root-path": "^2.0.1",
     "async-exit-hook": "^2.0.1",
+    "axios": "https://atomist.jfrog.io/atomist/npm-dev/axios/-/axios-0.17.1-proxy-fix-20180111160124.tgz",
     "base64-js": "^1.2.1",
     "cf-nodejs-client": "^0.13.0",
     "cfenv": "^1.0.4",

--- a/src/handlers/event/push/K8PodToPushLifecycle.ts
+++ b/src/handlers/event/push/K8PodToPushLifecycle.ts
@@ -18,15 +18,15 @@ import { PushLifecycleHandler } from "./PushLifecycle";
 export class K8PodToPushLifecycle extends PushLifecycleHandler<graphql.K8PodToPushLifecycle.Subscription> {
 
     protected extractNodes(event: EventFired<graphql.K8PodToPushLifecycle.Subscription>):
-        graphql.PushToPushLifecycle.Push[] {
+        graphql.K8PodToPushLifecycle.Pushes[] {
 
         const pushes = [];
-        event.data.K8Pod[0].images.forEach(i => pushes.push(...i.tag.commit.pushes));
+        event.data.K8Pod[0].images.forEach(i => pushes.push(...i.commits[0].pushes));
         return pushes;
     }
 
     protected extractChatTeams(event: EventFired<graphql.K8PodToPushLifecycle.Subscription>)
         : ChatTeam[] {
-        return _.get(event, "data.K8Pod[0].images[0].tag.commit.pushes[0].repo.org.team.chatTeams");
+        return _.get(event, "data.K8Pod[0].images[0].commits[0].pushes[0].repo.org.team.chatTeams");
     }
 }

--- a/src/handlers/event/push/rendering/PushNodeRenderers.ts
+++ b/src/handlers/event/push/rendering/PushNodeRenderers.ts
@@ -505,15 +505,14 @@ export class K8PodNodeRenderer extends AbstractIdentifiableContribution
     public render(push: graphql.PushToPushLifecycle.Push, actions: Action[],
                   msg: SlackMessage, context: RendererContext): Promise<SlackMessage> {
         const images = {};
-        push.commits.filter(c => c.tags != null).forEach(c => c.tags.filter(t => t.containers != null)
-            .forEach(t => t.containers.forEach(con => {
-                const image = con.image;
-                if (images[image]) {
-                    images[image].push(con);
+        push.commits.filter(c => c.tags != null && c.image != null).forEach(c => {
+                const imageName = c.image.imageName;
+                if (images[imageName]) {
+                    images[imageName].push(c.image);
                 } else {
-                    images[image] = [con];
+                    images[imageName] = [c.image];
                 }
-            })));
+            });
 
         const messages = [];
         // tslint:disable-next-line:forin

--- a/src/typings/types.d.ts
+++ b/src/typings/types.d.ts
@@ -78,16 +78,13 @@ export type _TagOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "id_asc" | "id_d
 export type _ReleaseOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "id_asc" | "id_desc" | "name_asc" | "name_desc" | "timestamp_asc" | "timestamp_desc";
 
 /* Ordering Enum for DockerImage */
-export type _DockerImageOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "image_asc" | "image_desc";
-
-/* Ordering Enum for K8Spec */
-export type _K8SpecOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "name_asc" | "name_desc" | "kind_asc" | "kind_desc" | "curHash_asc" | "curHash_desc" | "fsha_asc" | "fsha_desc" | "timestamp_asc" | "timestamp_desc";
+export type _DockerImageOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "image_asc" | "image_desc" | "imageName_asc" | "imageName_desc" | "timestamp_asc" | "timestamp_desc";
 
 /* Ordering Enum for K8Pod */
-export type _K8PodOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "name_asc" | "name_desc" | "state_asc" | "state_desc" | "host_asc" | "host_desc" | "timestamp_asc" | "timestamp_desc";
+export type _K8PodOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "name_asc" | "name_desc" | "phase_asc" | "phase_desc" | "environment_asc" | "environment_desc" | "timestamp_asc" | "timestamp_desc" | "baseName_asc" | "baseName_desc" | "namespace_asc" | "namespace_desc" | "statusJSON_asc" | "statusJSON_desc" | "host_asc" | "host_desc" | "state_asc" | "state_desc" | "specsJSON_asc" | "specsJSON_desc" | "envJSON_asc" | "envJSON_desc" | "metadataJSON_asc" | "metadataJSON_desc" | "resourceVersion_asc" | "resourceVersion_desc";
 
-/* Ordering Enum for Environment */
-export type _EnvironmentOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "name_asc" | "name_desc" | "vpcName_asc" | "vpcName_desc";
+/* Ordering Enum for K8Container */
+export type _K8ContainerOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "name_asc" | "name_desc" | "imageName_asc" | "imageName_desc" | "timestamp_asc" | "timestamp_desc" | "environment_asc" | "environment_desc" | "containerJSON_asc" | "containerJSON_desc" | "state_asc" | "state_desc" | "ready_asc" | "ready_desc" | "restartCount_asc" | "restartCount_desc" | "statusJSON_asc" | "statusJSON_desc" | "resourceVersion_asc" | "resourceVersion_desc";
 
 /* Ordering Enum for SpinnakerPipeline */
 export type _SpinnakerPipelineOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "executionId_asc" | "executionId_desc" | "application_asc" | "application_desc" | "eventType_asc" | "eventType_desc" | "taskName_asc" | "taskName_desc" | "stageName_asc" | "stageName_desc" | "stageType_asc" | "stageType_desc" | "waitingForJudgement_asc" | "waitingForJudgement_desc";
@@ -134,8 +131,8 @@ export type _CommentOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "id_asc" | "
 /* Ordering Enum for DeletedBranch */
 export type _DeletedBranchOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "id_asc" | "id_desc" | "name_asc" | "name_desc" | "timestamp_asc" | "timestamp_desc";
 
-/* Ordering Enum for K8Cluster */
-export type _K8ClusterOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "name_asc" | "name_desc" | "availabilityZone_asc" | "availabilityZone_desc";
+/* Ordering Enum for ImageLinked */
+export type _ImageLinkedOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "timestamp_asc" | "timestamp_desc";
 
 /* Ordering Enum for PushImpact */
 export type _PushImpactOrdering = "atmTeamId_asc" | "atmTeamId_desc" | "id_asc" | "id_desc" | "url_asc" | "url_desc" | "data_asc" | "data_desc";
@@ -999,6 +996,7 @@ export namespace ApplicationToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -1025,21 +1023,20 @@ export namespace ApplicationToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: _Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type _Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 
@@ -1918,6 +1915,7 @@ export namespace BuildToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -1944,21 +1942,20 @@ export namespace BuildToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: _Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type _Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 
@@ -3590,6 +3587,7 @@ export namespace IssueToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -3616,21 +3614,20 @@ export namespace IssueToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: _Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type _Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 
@@ -3659,214 +3656,8 @@ export namespace K8PodToPushLifecycle {
     _id?: Long | null; 
     name?: string | null; 
     state?: string | null; 
-    images?: Images[] | null; 
+    images?: DockerImage[] | null; 
     timestamp?: string | null; 
-  } 
-
-  export type Images = {
-    tag?: Tag | null; 
-  } 
-
-  export type Tag = {
-    commit?: Commit | null; 
-    timestamp?: string | null; 
-  } 
-
-  export type Commit = {
-    pushes?: Pushes[] | null; 
-    timestamp?: string | null; 
-  } 
-
-  export type Pushes = {
-    builds?: Builds[] | null; 
-    before?: Before | null; 
-    after?: After | null; 
-    repo?: Repo | null; 
-    commits?: Commits[] | null; 
-    timestamp?: string | null; 
-    branch?: string | null; 
-  } 
-
-  export type Builds = {
-    id?: string | null; 
-    buildUrl?: string | null; 
-    name?: string | null; 
-    provider?: string | null; 
-    status?: BuildStatus | null; 
-    commit?: _Commit | null; 
-    timestamp?: string | null; 
-    workflow?: Workflow | null; 
-  } 
-
-  export type _Commit = {
-    sha?: string | null; 
-  } 
-
-  export type Workflow = {
-    id?: string | null; 
-    name?: string | null; 
-    provider?: string | null; 
-    config?: string | null; 
-    builds?: _Builds[] | null; 
-  } 
-
-  export type _Builds = {
-    jobId?: string | null; 
-    jobName?: string | null; 
-    finishedAt?: string | null; 
-    startedAt?: string | null; 
-    status?: BuildStatus | null; 
-    id?: string | null; 
-    buildUrl?: string | null; 
-  } 
-
-  export type Before = {
-    sha?: string | null; 
-  } 
-
-  export type After = {
-    sha?: string | null; 
-    message?: string | null; 
-    statuses?: Statuses[] | null; 
-    tags?: Tags[] | null; 
-  } 
-
-  export type Statuses = {
-    context?: string | null; 
-    description?: string | null; 
-    targetUrl?: string | null; 
-    state?: StatusState | null; 
-  } 
-
-  export type Tags = {
-    name?: string | null; 
-    release?: Release | null; 
-    builds?: __Builds[] | null; 
-  } 
-
-  export type Release = {
-    name?: string | null; 
-  } 
-
-  export type __Builds = {
-    buildId?: string | null; 
-    buildUrl?: string | null; 
-    name?: string | null; 
-    provider?: string | null; 
-    status?: BuildStatus | null; 
-    timestamp?: string | null; 
-  } 
-
-  export type Repo = {
-    owner?: string | null; 
-    name?: string | null; 
-    channels?: Channels[] | null; 
-    labels?: Labels[] | null; 
-    org?: Org | null; 
-    defaultBranch?: string | null; 
-  } 
-
-  export type Channels = {
-    name?: string | null; 
-    team?: Team | null; 
-  } 
-
-  export type Team = {
-    id?: string | null; 
-  } 
-
-  export type Labels = {
-    name?: string | null; 
-  } 
-
-  export type Org = {
-    provider?: Provider | null; 
-    team?: _Team | null; 
-  } 
-
-  export type Provider = {
-    url?: string | null; 
-    apiUrl?: string | null; 
-    gitUrl?: string | null; 
-  } 
-
-  export type _Team = {
-    id?: string | null; 
-    chatTeams?: ChatTeams[] | null; 
-  } 
-
-  export type ChatTeams = {
-    id?: string | null; 
-    preferences?: Preferences[] | null; 
-  } 
-
-  export type Preferences = {
-    name?: string | null; 
-    value?: string | null; 
-  } 
-
-  export type Commits = {
-    sha?: string | null; 
-    message?: string | null; 
-    resolves?: Resolves[] | null; 
-    impact?: Impact | null; 
-    apps?: Apps[] | null; 
-    tags?: _Tags[] | null; 
-    author?: Author | null; 
-    timestamp?: string | null; 
-  } 
-
-  export type Resolves = {
-    number?: number | null; 
-    name?: string | null; 
-    title?: string | null; 
-    state?: IssueState | null; 
-  } 
-
-  export type Impact = {
-    data?: string | null; 
-    url?: string | null; 
-  } 
-
-  export type Apps = {
-    state?: string | null; 
-    host?: string | null; 
-    domain?: string | null; 
-    data?: string | null; 
-  } 
-
-  export type _Tags = {
-    name?: string | null; 
-    release?: _Release | null; 
-    containers?: Containers[] | null; 
-  } 
-
-  export type _Release = {
-    name?: string | null; 
-  } 
-
-  export type Containers = {
-    pods?: Pods[] | null; 
-    image?: string | null; 
-  } 
-
-  export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
-    name?: string | null; 
-  } 
-
-  export type Author = {
-    login?: string | null; 
-    person?: Person | null; 
-  } 
-
-  export type Person = {
-    chatId?: ChatId | null; 
-  } 
-
-  export type ChatId = {
-    screenName?: string | null; 
   } 
 }
 export namespace NotifyAuthorOnReview {
@@ -4726,6 +4517,7 @@ export namespace ParentImpactToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -4752,21 +4544,20 @@ export namespace ParentImpactToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: _Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type _Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 
@@ -5418,6 +5209,7 @@ export namespace PushToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -5444,21 +5236,20 @@ export namespace PushToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: _Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type _Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 
@@ -5730,6 +5521,7 @@ export namespace ReleaseToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -5756,21 +5548,20 @@ export namespace ReleaseToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: __Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type __Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 
@@ -6611,6 +6402,7 @@ export namespace StatusToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -6637,21 +6429,20 @@ export namespace StatusToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: _Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type _Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 
@@ -6822,6 +6613,7 @@ export namespace TagToPushLifecycle {
     impact?: Impact | null; 
     apps?: Apps[] | null; 
     tags?: _Tags[] | null; 
+    image?: Image | null; 
     author?: Author | null; 
     timestamp?: string | null; 
   } 
@@ -6848,21 +6640,20 @@ export namespace TagToPushLifecycle {
   export type _Tags = {
     name?: string | null; 
     release?: _Release | null; 
-    containers?: Containers[] | null; 
   } 
 
   export type _Release = {
     name?: string | null; 
   } 
 
-  export type Containers = {
+  export type Image = {
     pods?: Pods[] | null; 
-    image?: string | null; 
+    imageName?: string | null; 
   } 
 
   export type Pods = {
-    host?: string | null; 
-    state?: string | null; 
+    baseName?: string | null; 
+    phase?: string | null; 
     name?: string | null; 
   } 
 

--- a/src/typings/types.d.ts
+++ b/src/typings/types.d.ts
@@ -3656,8 +3656,209 @@ export namespace K8PodToPushLifecycle {
     _id?: Long | null; 
     name?: string | null; 
     state?: string | null; 
-    images?: DockerImage[] | null; 
+    images?: Images[] | null; 
+  } 
+
+  export type Images = {
+    commits?: Commits[] | null; 
     timestamp?: string | null; 
+  } 
+
+  export type Commits = {
+    pushes?: Pushes[] | null; 
+    timestamp?: string | null; 
+  } 
+
+  export type Pushes = {
+    builds?: Builds[] | null; 
+    before?: Before | null; 
+    after?: After | null; 
+    repo?: Repo | null; 
+    commits?: _Commits[] | null; 
+    timestamp?: string | null; 
+    branch?: string | null; 
+  } 
+
+  export type Builds = {
+    id?: string | null; 
+    buildUrl?: string | null; 
+    name?: string | null; 
+    provider?: string | null; 
+    status?: BuildStatus | null; 
+    commit?: Commit | null; 
+    timestamp?: string | null; 
+    workflow?: Workflow | null; 
+  } 
+
+  export type Commit = {
+    sha?: string | null; 
+  } 
+
+  export type Workflow = {
+    id?: string | null; 
+    name?: string | null; 
+    provider?: string | null; 
+    config?: string | null; 
+    builds?: _Builds[] | null; 
+  } 
+
+  export type _Builds = {
+    jobId?: string | null; 
+    jobName?: string | null; 
+    finishedAt?: string | null; 
+    startedAt?: string | null; 
+    status?: BuildStatus | null; 
+    id?: string | null; 
+    buildUrl?: string | null; 
+  } 
+
+  export type Before = {
+    sha?: string | null; 
+  } 
+
+  export type After = {
+    sha?: string | null; 
+    message?: string | null; 
+    statuses?: Statuses[] | null; 
+    tags?: Tags[] | null; 
+  } 
+
+  export type Statuses = {
+    context?: string | null; 
+    description?: string | null; 
+    targetUrl?: string | null; 
+    state?: StatusState | null; 
+  } 
+
+  export type Tags = {
+    name?: string | null; 
+    release?: Release | null; 
+    builds?: __Builds[] | null; 
+  } 
+
+  export type Release = {
+    name?: string | null; 
+  } 
+
+  export type __Builds = {
+    buildId?: string | null; 
+    buildUrl?: string | null; 
+    name?: string | null; 
+    provider?: string | null; 
+    status?: BuildStatus | null; 
+    timestamp?: string | null; 
+  } 
+
+  export type Repo = {
+    owner?: string | null; 
+    name?: string | null; 
+    channels?: Channels[] | null; 
+    labels?: Labels[] | null; 
+    org?: Org | null; 
+    defaultBranch?: string | null; 
+  } 
+
+  export type Channels = {
+    name?: string | null; 
+    team?: Team | null; 
+  } 
+
+  export type Team = {
+    id?: string | null; 
+  } 
+
+  export type Labels = {
+    name?: string | null; 
+  } 
+
+  export type Org = {
+    provider?: Provider | null; 
+    team?: _Team | null; 
+  } 
+
+  export type Provider = {
+    url?: string | null; 
+    apiUrl?: string | null; 
+    gitUrl?: string | null; 
+  } 
+
+  export type _Team = {
+    id?: string | null; 
+    chatTeams?: ChatTeams[] | null; 
+  } 
+
+  export type ChatTeams = {
+    id?: string | null; 
+    preferences?: Preferences[] | null; 
+  } 
+
+  export type Preferences = {
+    name?: string | null; 
+    value?: string | null; 
+  } 
+
+  export type _Commits = {
+    sha?: string | null; 
+    message?: string | null; 
+    resolves?: Resolves[] | null; 
+    impact?: Impact | null; 
+    apps?: Apps[] | null; 
+    tags?: _Tags[] | null; 
+    image?: Image | null; 
+    author?: Author | null; 
+    timestamp?: string | null; 
+  } 
+
+  export type Resolves = {
+    number?: number | null; 
+    name?: string | null; 
+    title?: string | null; 
+    state?: IssueState | null; 
+  } 
+
+  export type Impact = {
+    data?: string | null; 
+    url?: string | null; 
+  } 
+
+  export type Apps = {
+    state?: string | null; 
+    host?: string | null; 
+    domain?: string | null; 
+    data?: string | null; 
+  } 
+
+  export type _Tags = {
+    name?: string | null; 
+    release?: _Release | null; 
+  } 
+
+  export type _Release = {
+    name?: string | null; 
+  } 
+
+  export type Image = {
+    pods?: Pods[] | null; 
+    imageName?: string | null; 
+  } 
+
+  export type Pods = {
+    baseName?: string | null; 
+    phase?: string | null; 
+    name?: string | null; 
+  } 
+
+  export type Author = {
+    login?: string | null; 
+    person?: Person | null; 
+  } 
+
+  export type Person = {
+    chatId?: ChatId | null; 
+  } 
+
+  export type ChatId = {
+    screenName?: string | null; 
   } 
 }
 export namespace NotifyAuthorOnReview {


### PR DESCRIPTION
This is a pretty simple change to rename the Pod and Image attributes that were causing errors today when neo-ingester was released in staging. I'd like to update the `/src/typings/types.d.ts` to reflect these changes, and then find all the usages that will be broken and change them. I shouldn't modify `types.d.ts` directly, it gets regenerated on compile.
When it regenerates, it is missing the new field names. I'm guessing that I also need to change node_modules/@atomist/automation-client/graph/schema.cortex.json to reflect the changed K8 attributes, release it, and update the dependency here? I don't know if that change is supposed to be done manually.
