### PR TITLE
Provide more channel options in PushToUnmappedRepo

### DIFF
--- a/src/handlers/event/channellink/BotJoinedChannel.ts
+++ b/src/handlers/event/channellink/BotJoinedChannel.ts
@@ -104,9 +104,12 @@ I don't see any repositories in GitHub${ownerText}.`;
 
             const msgId = `channel_link/bot_joined_channel/${channelName}`;
 
-            const matchyRepos = allRepos.filter(r =>
-                repoChannelName(r.name).indexOf(channelName) > -1 ||
-                channelName.indexOf(repoChannelName(r.name)) > -1).slice(0, 2);
+            const matchyRepos = allRepos
+                .filter(r => {
+                    const rcName = repoChannelName(r.name);
+                    return rcName.includes(channelName) || channelName.includes(rcName);
+                })
+                .sort((a, b) => a.name.length - b.name.length).slice(0, 2);
             const actions: slack.Action[] = [];
             matchyRepos.forEach(r => {
                 const linkRepo = new LinkRepo();

--- a/test/handlers/event/push/PushToUnmappedRepoTest.ts
+++ b/test/handlers/event/push/PushToUnmappedRepoTest.ts
@@ -1,14 +1,18 @@
 import "mocha";
 import * as assert from "power-assert";
 
+import * as slack from "@atomist/slack-messages/SlackMessages";
+
 import { DefaultBotName } from "../../../../src/handlers/command/slack/LinkRepo";
 import {
     extractScreenNameFromMapRepoMessageId,
+    fuzzyRepoChannelMatch,
     leaveRepoUnmapped,
     mapRepoMessage,
     mapRepoMessageId,
     repoString,
 } from "../../../../src/handlers/event/push/PushToUnmappedRepo";
+import * as graphql from "../../../../src/typings/types";
 
 describe("PushToUnmappedRepo", () => {
 
@@ -106,7 +110,106 @@ describe("PushToUnmappedRepo", () => {
 
     });
 
+    describe("fuzzyRepoChannelMatch", () => {
+
+        it("should find nothing", () => {
+            const repo = "gram-parsons";
+            const channels: graphql.PushToUnmappedRepo.Channels[] = [
+                { name: "emmylou-harris" },
+                { name: "chris-hillman" },
+            ];
+            assert(fuzzyRepoChannelMatch(repo, channels).length === 0);
+        });
+
+        it("should find a shorter match", () => {
+            const repo = "gram-parsons";
+            const channels: graphql.PushToUnmappedRepo.Channels[] = [
+                { name: "emmylou-harris" },
+                { name: "gram" },
+                { name: "chris-hillman" },
+            ];
+            const matches = fuzzyRepoChannelMatch(repo, channels);
+            assert(matches.length === 1);
+            assert(matches[0].name === "gram");
+        });
+
+        it("should find a longer match", () => {
+            const repo = "gram-parsons";
+            const channels: graphql.PushToUnmappedRepo.Channels[] = [
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "chris-hillman" },
+            ];
+            const matches = fuzzyRepoChannelMatch(repo, channels);
+            assert(matches.length === 1);
+            assert(matches[0].name === "gram-parsons-and-the-fallen-angels");
+        });
+
+        it("should find all matches", () => {
+            const repo = "gram-parsons";
+            const channels: graphql.PushToUnmappedRepo.Channels[] = [
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "chris-hillman" },
+                { name: "gram" },
+            ];
+            const matches = fuzzyRepoChannelMatch(repo, channels);
+            assert(matches.length === 2);
+            assert(matches[0].name === "gram");
+            assert(matches[1].name === "gram-parsons-and-the-fallen-angels");
+        });
+
+        it("should find only two matches", () => {
+            const repo = "gram-parsons";
+            const channels: graphql.PushToUnmappedRepo.Channels[] = [
+                { name: "parsons" },
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "chris-hillman" },
+                { name: "gram" },
+                { name: "am" },
+            ];
+            const matches = fuzzyRepoChannelMatch(repo, channels);
+            assert(matches.length === 2);
+            assert(matches[0].name === "parsons");
+            assert(matches[1].name === "gram");
+        });
+
+        it("should find the best two matches", () => {
+            const repo = "gram-parsons";
+            const channels: graphql.PushToUnmappedRepo.Channels[] = [
+                { name: "parsons" },
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "gram-parson" },
+                { name: "chris-hillman" },
+                { name: "gram" },
+                { name: "gram-parsonsx" },
+                { name: "gram-par" },
+            ];
+            const matches = fuzzyRepoChannelMatch(repo, channels);
+            assert(matches.length === 2);
+            assert(matches[0].name === "gram-parson");
+            assert(matches[1].name === "gram-parsonsx");
+        });
+
+    });
+
     describe("mapRepoMessage", () => {
+
+        function assertStop(stopMsg: slack.Attachment) {
+            const stopText = "stop receiving similar suggestions for all repositories";
+            assert(stopMsg.text.includes(stopText));
+            assert(stopMsg.fallback.includes(stopText));
+            assert(stopMsg.actions.length === 1);
+            assert(stopMsg.actions[0].text === "All Repositories");
+            assert(stopMsg.actions[0].type === "button");
+            const allStopCmd = (stopMsg.actions[0] as any).command;
+            assert(allStopCmd.name === "SetUserPreference");
+            assert(allStopCmd.parameters.key === "dm");
+            assert(allStopCmd.parameters.name === "disable_for_mapRepo");
+            assert(allStopCmd.parameters.value === "true");
+        }
 
         it("should send a message offering to create channel and link a repo to it", () => {
             const repo = {
@@ -117,12 +220,7 @@ describe("PushToUnmappedRepo", () => {
                     team: {
                         chatTeams: [{
                             id: "TEAMID",
-                            channels: [
-                                {
-                                    channelId: "C1000WED",
-                                    name: "1000-wedding",
-                                },
-                            ],
+                            channels: [{ channelId: "C1000WED", name: "1000-wedding" }],
                         }],
                     },
                 },
@@ -138,16 +236,14 @@ describe("PushToUnmappedRepo", () => {
                 },
             };
             const repoLink = "<https://github.com/grievous-angel/sin-city|grievous-angel/sin-city>";
-            const channelText = "*#sin-city*";
             const msg = mapRepoMessage(repo, chatId, DefaultBotName);
             assert(msg.attachments.length === 3);
             const linkMsg = msg.attachments[0];
             const hintMsg = msg.attachments[1];
             const stopMsg = msg.attachments[2];
-            assert(linkMsg.pretext.indexOf(repoLink) > 0);
-            assert(linkMsg.pretext.indexOf(channelText) > 0);
-            assert(linkMsg.actions.length === 1);
-            assert(linkMsg.actions[0].text === "Go ahead");
+            assert(linkMsg.pretext.includes(repoLink));
+            assert(linkMsg.actions.length === 2);
+            assert(linkMsg.actions[0].text === `Create #sin-city`);
             assert(linkMsg.actions[0].type === "button");
             const command = (linkMsg.actions[0] as any).command;
             assert(command.name === "CreateChannel");
@@ -155,20 +251,20 @@ describe("PushToUnmappedRepo", () => {
             assert(command.parameters.channel === "sin-city");
             assert(command.parameters.owner === "grievous-angel");
             assert(command.parameters.repo === "sin-city");
+            assert(linkMsg.actions[1].text === "Other channel...");
+            assert(linkMsg.actions[1].type === "select");
+            assert.deepEqual(linkMsg.actions[1].options, [{ text: "1000-wedding", value: "1000-wedding" }]);
+            const menuCommand = (linkMsg.actions[1] as any).command;
+            assert(menuCommand.name === "CreateChannel");
+            assert(menuCommand.parameterName === "channel");
+            assert(menuCommand.parameters.apiUrl === undefined);
+            assert(menuCommand.parameters.channel === undefined);
+            assert(menuCommand.parameters.owner === "grievous-angel");
+            assert(menuCommand.parameters.repo === "sin-city");
             const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
 '@atomist repo owner=grievous-angel name=sin-city'`;
             assert(hintMsg.fallback === hintFallBack);
-            const stopText = "stop receiving similar suggestions for all repositories";
-            assert(stopMsg.text.includes(stopText));
-            assert(stopMsg.fallback.includes(stopText));
-            assert(stopMsg.actions.length === 1);
-            assert(stopMsg.actions[0].text === "All Repositories");
-            assert(stopMsg.actions[0].type === "button");
-            const allStopCmd = (stopMsg.actions[0] as any).command;
-            assert(allStopCmd.name === "SetUserPreference");
-            assert(allStopCmd.parameters.key === "dm");
-            assert(allStopCmd.parameters.name === "disable_for_mapRepo");
-            assert(allStopCmd.parameters.value === "true");
+            assertStop(stopMsg);
         });
 
         it("should send a message offering to link a repo to existing channel", () => {
@@ -186,14 +282,10 @@ describe("PushToUnmappedRepo", () => {
                         chatTeams: [{
                             id: "TEAMID",
                             channels: [
-                                {
-                                    channelId: "C1000WED",
-                                    name: "1000-wedding",
-                                },
-                                {
-                                    channelId: "C51NC1TY",
-                                    name: "sin-city",
-                                },
+                                { channelId: "C1000WED", name: "1000-wedding" },
+                                { channelId: "C51NC1TY", name: "sin-city" },
+                                { channelId: "CBAL1M0RE", name: "streets-of-baltimore" },
+                                { channelId: "CBRA55BUTT0N5", name: "brass-buttons" },
                             ],
                         }],
                     },
@@ -216,7 +308,6 @@ describe("PushToUnmappedRepo", () => {
                 },
             };
             const repoLink = "<https://ghe.gram-parsons.com/grievous-angel/sin-city|grievous-angel/sin-city>";
-            const channelText = "<#C51NC1TY>";
             const bot = "hillman";
             const msg = mapRepoMessage(repo, chatId, bot);
             assert(msg.attachments.length === 3);
@@ -224,30 +315,185 @@ describe("PushToUnmappedRepo", () => {
             const hintMsg = msg.attachments[1];
             const stopMsg = msg.attachments[2];
             assert(linkMsg.pretext.indexOf(repoLink) > 0);
-            assert(linkMsg.pretext.indexOf(channelText) > 0);
-            assert(linkMsg.actions.length === 1);
-            assert(linkMsg.actions[0].text === "Go ahead");
+            assert(linkMsg.actions.length === 2);
+            assert(linkMsg.actions[0].text === "#sin-city");
             assert(linkMsg.actions[0].type === "button");
             const command = (linkMsg.actions[0] as any).command;
-            assert(command.name === "AssociateRepo");
+            assert(command.name === "CreateChannel");
             assert(command.parameters.apiUrl === "https://ghe.gram-parsons.com/v3/");
-            assert(command.parameters.channelId === "C51NC1TY");
+            assert(command.parameters.channel === "sin-city");
             assert(command.parameters.owner === "grievous-angel");
             assert(command.parameters.repo === "sin-city");
+            assert(linkMsg.actions[1].text === "Other channel...");
+            assert(linkMsg.actions[1].type === "select");
+            assert.deepEqual(linkMsg.actions[1].options, [
+                { text: "1000-wedding", value: "1000-wedding" },
+                { text: "brass-buttons", value: "brass-buttons" },
+                { text: "sin-city", value: "sin-city" },
+                { text: "streets-of-baltimore", value: "streets-of-baltimore" },
+            ]);
+            const menuCommand = (linkMsg.actions[1] as any).command;
+            assert(menuCommand.name === "CreateChannel");
+            assert(menuCommand.parameterName === "channel");
+            assert(menuCommand.parameters.apiUrl === "https://ghe.gram-parsons.com/v3/");
+            assert(menuCommand.parameters.channel === undefined);
+            assert(menuCommand.parameters.owner === "grievous-angel");
+            assert(menuCommand.parameters.repo === "sin-city");
             const hintFallBack = `or '/invite @${bot}' me to a relevant channel and type
 '@${bot} repo owner=grievous-angel name=sin-city'`;
             assert(hintMsg.fallback === hintFallBack);
-            const stopText = "stop receiving similar suggestions for all repositories";
-            assert(stopMsg.text.includes(stopText));
-            assert(stopMsg.fallback.includes(stopText));
-            assert(stopMsg.actions.length === 1);
-            assert(stopMsg.actions[0].text === "All Repositories");
-            assert(stopMsg.actions[0].type === "button");
-            const allStopCmd = (stopMsg.actions[0] as any).command;
-            assert(allStopCmd.name === "SetUserPreference");
-            assert(allStopCmd.parameters.key === "dm");
-            assert(allStopCmd.parameters.name === "disable_for_mapRepo");
-            assert(allStopCmd.parameters.value === "true");
+            assertStop(stopMsg);
+        });
+
+        it("should send a message with matchy channel buttons", () => {
+            const repo = {
+                name: "sin-city",
+                owner: "grievous-angel",
+                channels: [],
+                org: {
+                    team: {
+                        chatTeams: [{
+                            id: "TEAMID",
+                            channels: [
+                                { name: "1000-wedding", channelId: "C1000WED" },
+                                { name: "sin-city-1", channelId: "C51NC1TY1" },
+                                { name: "sin-city-21", channelId: "C51NC1TY21" },
+                                { name: "streets-of-baltimore", channelId: "CBAL1M0RE" },
+                                { name: "sin-city-2", channelId: "C51NC1TY2" },
+                                { name: "brass-buttons", channelId: "CBRA55BUTT0N5" },
+                            ],
+                        }],
+                    },
+                },
+            };
+            const chatId = {
+                screenName: "gram",
+                preferences: [{
+                    name: "repo_mapping_flow",
+                    value: JSON.stringify({}),
+                }],
+                chatTeam: {
+                    id: "TEAMID",
+                },
+            };
+            const repoLink = "<https://github.com/grievous-angel/sin-city|grievous-angel/sin-city>";
+            const msg = mapRepoMessage(repo, chatId, DefaultBotName);
+            assert(msg.attachments.length === 3);
+            const linkMsg = msg.attachments[0];
+            const hintMsg = msg.attachments[1];
+            const stopMsg = msg.attachments[2];
+            assert(linkMsg.pretext.includes(repoLink));
+            assert(linkMsg.actions.length === 4);
+            assert(linkMsg.actions[0].text === `Create #sin-city`);
+            assert(linkMsg.actions[0].type === "button");
+            const command = (linkMsg.actions[0] as any).command;
+            assert(command.name === "CreateChannel");
+            assert(command.parameters.apiUrl === undefined);
+            assert(command.parameters.channel === "sin-city");
+            assert(command.parameters.owner === "grievous-angel");
+            assert(command.parameters.repo === "sin-city");
+            assert(linkMsg.actions[1].text === "#sin-city-1");
+            assert(linkMsg.actions[1].type === "button");
+            const cmd1 = (linkMsg.actions[1] as any).command;
+            assert(cmd1.name === "CreateChannel");
+            assert(cmd1.parameters.apiUrl === undefined);
+            assert(cmd1.parameters.channel === "sin-city-1");
+            assert(cmd1.parameters.owner === "grievous-angel");
+            assert(cmd1.parameters.repo === "sin-city");
+            assert(linkMsg.actions[2].text === "#sin-city-2");
+            assert(linkMsg.actions[2].type === "button");
+            const cmd2 = (linkMsg.actions[2] as any).command;
+            assert(cmd2.name === "CreateChannel");
+            assert(cmd2.parameters.apiUrl === undefined);
+            assert(cmd2.parameters.channel === "sin-city-2");
+            assert(cmd2.parameters.owner === "grievous-angel");
+            assert(cmd2.parameters.repo === "sin-city");
+            assert(linkMsg.actions[3].text === "Other channel...");
+            assert(linkMsg.actions[3].type === "select");
+            assert.deepEqual(linkMsg.actions[3].options, [
+                { text: "1000-wedding", value: "1000-wedding" },
+                { text: "brass-buttons", value: "brass-buttons" },
+                { text: "sin-city-1", value: "sin-city-1" },
+                { text: "sin-city-2", value: "sin-city-2" },
+                { text: "sin-city-21", value: "sin-city-21" },
+                { text: "streets-of-baltimore", value: "streets-of-baltimore" },
+            ]);
+            const menuCommand = (linkMsg.actions[3] as any).command;
+            assert(menuCommand.name === "CreateChannel");
+            assert(menuCommand.parameterName === "channel");
+            assert(menuCommand.parameters.apiUrl === undefined);
+            assert(menuCommand.parameters.channel === undefined);
+            assert(menuCommand.parameters.owner === "grievous-angel");
+            assert(menuCommand.parameters.repo === "sin-city");
+            const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
+'@atomist repo owner=grievous-angel name=sin-city'`;
+            assert(hintMsg.fallback === hintFallBack);
+            assertStop(stopMsg);
+        });
+
+        it("should send a message with no selector if all channels already listed", () => {
+            const repo = {
+                name: "sin-city",
+                owner: "grievous-angel",
+                channels: [],
+                org: {
+                    team: {
+                        chatTeams: [{
+                            id: "TEAMID",
+                            channels: [
+                                { channelId: "C51NC1TY1", name: "sin-city-1" },
+                                { channelId: "C51NC1TY2", name: "sin-city-2" },
+                            ],
+                        }],
+                    },
+                },
+            };
+            const chatId = {
+                screenName: "gram",
+                preferences: [{
+                    name: "repo_mapping_flow",
+                    value: JSON.stringify({}),
+                }],
+                chatTeam: {
+                    id: "TEAMID",
+                },
+            };
+            const repoLink = "<https://github.com/grievous-angel/sin-city|grievous-angel/sin-city>";
+            const msg = mapRepoMessage(repo, chatId, DefaultBotName);
+            assert(msg.attachments.length === 3);
+            const linkMsg = msg.attachments[0];
+            const hintMsg = msg.attachments[1];
+            const stopMsg = msg.attachments[2];
+            assert(linkMsg.pretext.includes(repoLink));
+            assert(linkMsg.actions.length === 3);
+            assert(linkMsg.actions[0].text === `Create #sin-city`);
+            assert(linkMsg.actions[0].type === "button");
+            const command = (linkMsg.actions[0] as any).command;
+            assert(command.name === "CreateChannel");
+            assert(command.parameters.apiUrl === undefined);
+            assert(command.parameters.channel === "sin-city");
+            assert(command.parameters.owner === "grievous-angel");
+            assert(command.parameters.repo === "sin-city");
+            assert(linkMsg.actions[1].text === "#sin-city-1");
+            assert(linkMsg.actions[1].type === "button");
+            const cmd1 = (linkMsg.actions[1] as any).command;
+            assert(cmd1.name === "CreateChannel");
+            assert(cmd1.parameters.apiUrl === undefined);
+            assert(cmd1.parameters.channel === "sin-city-1");
+            assert(cmd1.parameters.owner === "grievous-angel");
+            assert(cmd1.parameters.repo === "sin-city");
+            assert(linkMsg.actions[2].text === "#sin-city-2");
+            assert(linkMsg.actions[2].type === "button");
+            const cmd2 = (linkMsg.actions[2] as any).command;
+            assert(cmd2.name === "CreateChannel");
+            assert(cmd2.parameters.apiUrl === undefined);
+            assert(cmd2.parameters.channel === "sin-city-2");
+            assert(cmd2.parameters.owner === "grievous-angel");
+            assert(cmd2.parameters.repo === "sin-city");
+            const hintFallBack = `or '/invite @atomist' me to a relevant channel and type
+'@atomist repo owner=grievous-angel name=sin-city'`;
+            assert(hintMsg.fallback === hintFallBack);
+            assertStop(stopMsg);
         });
 
     });


### PR DESCRIPTION
Allow committer to unmapped repo to select any repository, providing
buttons for similarly named channels if no exact match exists.  If all
available channels are available as buttons, do not provide menu.

Fix bug when setting Atomist bot name.

Closes #89.