### PR TITLE
Provide `pathPrefix` to GitHubApi

### DIFF
--- a/src/handlers/command/github/gitHubApi.ts
+++ b/src/handlers/command/github/gitHubApi.ts
@@ -15,6 +15,7 @@ export function api(token: string, apiUrl: string = "https://api.github.com/"): 
 
     const gitHubApi = new GitHubApi({
         host: url.hostname,
+        pathPrefix: url.pathname,
         protocol: url.protocol.slice(0, -1),
         port: +url.port,
     });


### PR DESCRIPTION
GHE instances typically have a path, so make sure the one parsed from
the URL gets passed along.

Closes #121