### PR TITLE
Get repo list from GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Do not match partial image URLs [#104][104]
 -   Provide path to GitHubApi for GHE instances [#121][121]
 -   Account for channels without names [#123][123]
+-   Fetch repositories from GitHub [#59][59]
 
 [104]: https://github.com/atomist/lifecycle-automation/issues/104
 [121]: https://github.com/atomist/lifecycle-automation/issues/121
 [123]: https://github.com/atomist/lifecycle-automation/issues/123
+[59]: https://github.com/atomist/lifecycle-automation/issues/59
 
 ## [0.2.6][] - 2017-11-15
 

--- a/src/graphql/subscription/botJoinedChannel.graphql
+++ b/src/graphql/subscription/botJoinedChannel.graphql
@@ -22,6 +22,7 @@ subscription BotJoinedChannel {
         id
         orgs {
           owner
+          ownerType
           provider {
             apiUrl
           }

--- a/src/handlers/command/github/gitHubApi.ts
+++ b/src/handlers/command/github/gitHubApi.ts
@@ -9,7 +9,9 @@ import * as GitHubApi from "github";
 import * as URL from "url";
 import { error } from "../../../util/messages";
 
-export function api(token: string, apiUrl: string = "https://api.github.com/"): GitHubApi {
+export const DefaultGitHubApiUrl = "https://api.github.com/";
+
+export function api(token: string, apiUrl: string = DefaultGitHubApiUrl): GitHubApi {
     // separate the url
     const url = URL.parse(apiUrl);
 

--- a/src/handlers/event/push/PushToUnmappedRepo.ts
+++ b/src/handlers/event/push/PushToUnmappedRepo.ts
@@ -186,6 +186,18 @@ function populateMapCommand(c: CreateChannel, repo: graphql.PushToUnmappedRepo.R
     return c;
 }
 
+/**
+ * Find the best `max` channel name matches with `repo`.  To
+ * match either the repository name must be contained in the channel
+ * name or vice versa.  Matches are rated more highly if the
+ * difference in length between the channel and repository names is
+ * smaller, sorting matches with the same length difference by name.
+ *
+ * @param repo name of repository
+ * @param channels channels to search for matches
+ * @param max maximum number of repositories to return
+ * @return array of `max` matching channels
+ */
 export function fuzzyRepoChannelMatch(
     repo: string,
     channels: graphql.PushToUnmappedRepo.Channels[],

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -1748,6 +1748,7 @@ export namespace BotJoinedChannel {
 
   export type Orgs = {
     owner?: string | null; 
+    ownerType?: OwnerType | null; 
     provider?: _Provider | null; 
     repo?: Repo[] | null; 
   } 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -2,6 +2,7 @@ import { HandlerContext } from "@atomist/automation-client";
 import { logger } from "@atomist/automation-client/internal/util/logger";
 import * as slack from "@atomist/slack-messages/SlackMessages";
 import * as _ from "lodash";
+import { DefaultGitHubApiUrl } from "../handlers/command/github/gitHubApi";
 import { DirectMessagePreferences } from "../handlers/event/preferences";
 import * as graphql from "../typings/types";
 
@@ -91,7 +92,7 @@ export function apiUrl(repo: any): string {
         }
         return providerUrl;
     } else {
-        return "https://api.github.com";
+        return DefaultGitHubApiUrl;
     }
 }
 

--- a/test/handlers/event/channelLink/BotJoinedChannelTest.ts
+++ b/test/handlers/event/channelLink/BotJoinedChannelTest.ts
@@ -2,42 +2,155 @@ import "mocha";
 import * as assert from "power-assert";
 
 import * as slack from "@atomist/slack-messages/SlackMessages";
+import axios from "axios";
 
 import { Destination, MessageOptions } from "@atomist/automation-client/spi/message/MessageClient";
-import { BotJoinedChannel, repoOptions } from "../../../../src/handlers/event/channellink/BotJoinedChannel";
+import {
+    BotJoinedChannel,
+    fuzzyChannelRepoMatch,
+    RepoApi,
+    repoOptions,
+} from "../../../../src/handlers/event/channellink/BotJoinedChannel";
+import * as graphql from "../../../../src/typings/types";
 
 describe("BotJoinedChannel", () => {
 
-    const orgs = [
-        {
-            owner: "jon",
-            repo: [
+    describe("fuzzyChannelRepoMatch", () => {
+
+        it("should find nothing", () => {
+            const channel = "gram-parsons";
+            const repos: graphql.BotJoinedChannel.Repo[] = [
+                { name: "international_submarine_band" },
+                { name: "the-byrds" },
+                { name: "chris-hillman" },
+                { name: "flying-burrito-brothers" },
+                { name: "emmylou-harris" },
+            ];
+            assert(fuzzyChannelRepoMatch(channel, repos).length === 0);
+        });
+
+        it("should find a shorter match", () => {
+            const channel = "gram-parsons";
+            const repos: graphql.BotJoinedChannel.Repo[] = [
+                { name: "emmylou-harris" },
+                { name: "gram" },
+                { name: "chris-hillman" },
+            ];
+            const matches = fuzzyChannelRepoMatch(channel, repos);
+            assert(matches.length === 1);
+            assert(matches[0].name === "gram");
+        });
+
+        it("should find a longer match", () => {
+            const channel = "gram-parsons";
+            const repos: graphql.BotJoinedChannel.Repo[] = [
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "chris-hillman" },
+            ];
+            const matches = fuzzyChannelRepoMatch(channel, repos);
+            assert(matches.length === 1);
+            assert(matches[0].name === "gram-parsons-and-the-fallen-angels");
+        });
+
+        it("should find all matches", () => {
+            const channel = "gram-parsons";
+            const repos: graphql.BotJoinedChannel.Repo[] = [
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "chris-hillman" },
+                { name: "am-par" },
+            ];
+            const matches = fuzzyChannelRepoMatch(channel, repos);
+            assert(matches.length === 2);
+            assert(matches[0].name === "am-par");
+            assert(matches[1].name === "gram-parsons-and-the-fallen-angels");
+        });
+
+        it("should find only two matches", () => {
+            const channel = "gram-parsons";
+            const repos: graphql.BotJoinedChannel.Repo[] = [
+                { name: "parsons" },
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "chris-hillman" },
+                { name: "gram" },
+                { name: "am" },
+            ];
+            const matches = fuzzyChannelRepoMatch(channel, repos);
+            assert(matches.length === 2);
+            assert(matches[0].name === "parsons");
+            assert(matches[1].name === "gram");
+        });
+
+        it("should find the best two matches", () => {
+            const channel = "gram-parsons";
+            const repos: graphql.BotJoinedChannel.Repo[] = [
+                { name: "parsons" },
+                { name: "emmylou-harris" },
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "gram-parson" },
+                { name: "chris-hillman" },
+                { name: "gram" },
+                { name: "gram-parsonsx" },
+                { name: "gram-par" },
+            ];
+            const matches = fuzzyChannelRepoMatch(channel, repos);
+            assert(matches.length === 2);
+            assert(matches[0].name === "gram-parson");
+            assert(matches[1].name === "gram-parsonsx");
+        });
+
+        it("should find the best two matches when some repos names are null", () => {
+            const channel = "gram-parsons";
+            const repos: graphql.BotJoinedChannel.Repo[] = [
+                { name: "parsons" },
+                { name: "emmylou-harris" },
+                {},
+                { name: "gram-parsons-and-the-fallen-angels" },
+                { name: "gram-parson" },
+                { name: "chris-hillman" },
+                { name: "gram" },
+                { name: null },
+                { name: "gram-parsonsx" },
+                { name: "gram-par" },
+            ];
+            const matches = fuzzyChannelRepoMatch(channel, repos);
+            assert(matches.length === 2);
+            assert(matches[0].name === "gram-parson");
+            assert(matches[1].name === "gram-parsonsx");
+        });
+
+    });
+
+    describe("repoOptions", () => {
+
+        const lolRepos: RepoApi[][] = [
+            [
                 {
                     name: "7-mary-3",
                     owner: "jon",
+                    api: undefined,
                 },
                 {
                     name: "79-charles",
                     owner: "jon",
+                    api: undefined,
                 },
             ],
-        },
-        {
-            owner: "ponch",
-            repo: [
+            [
                 {
                     name: "7-mary-4",
                     owner: "ponch",
+                    api: "https://ghe.chp.gov/v3/",
                 },
                 {
                     name: "79-mary-4",
                     owner: "ponch",
+                    api: "https://ghe.chp.gov/v3/",
                 },
             ],
-        },
-    ];
-
-    describe("repoOptions", () => {
+        ];
 
         it("should create an option group", () => {
             const e = [
@@ -46,11 +159,11 @@ describe("BotJoinedChannel", () => {
                     options: [
                         {
                             text: "7-mary-3",
-                            value: "jon/7-mary-3",
+                            value: "jon/7-mary-3|",
                         },
                         {
                             text: "79-charles",
-                            value: "jon/79-charles",
+                            value: "jon/79-charles|",
                         },
                     ],
                 },
@@ -59,72 +172,135 @@ describe("BotJoinedChannel", () => {
                     options: [
                         {
                             text: "7-mary-4",
-                            value: "ponch/7-mary-4",
+                            value: "ponch/7-mary-4|https://ghe.chp.gov/v3/",
                         },
                         {
                             text: "79-mary-4",
-                            value: "ponch/79-mary-4",
+                            value: "ponch/79-mary-4|https://ghe.chp.gov/v3/",
                         },
                     ],
                 },
             ];
-            assert.deepEqual(repoOptions(orgs), e);
+            assert.deepEqual(repoOptions(lolRepos), e);
         });
 
     });
 
     describe("handle", () => {
 
-        const event = {
-            data: {
-                UserJoinedChannel: [{
-                    user: {
-                        isAtomistBot: "true",
-                        screenName: "atomist_bot",
-                        userId: "U1234567",
-                    },
-                    channel: {
-                        botInvitedSelf: false,
-                        channelId: "CHP87654P",
-                        name: "ponch",
-                        repos: [
-                            {
-                                name: "n",
-                                owner: "n",
-                                org: {
-                                    provider: {
-                                        url: "https://ghe.chp.gov/",
-                                    },
-                                },
-                            },
-                        ],
-                        team: {
-                            id: "T1L0VDKJP",
-                            orgs: [
-                                {
-                                    owner: "n",
-                                    provider: {
-                                        apiUrl: "https://ghe.chp.gov/v3/",
-                                    },
-                                    repo: [
-                                        {
-                                            name: "n",
-                                            owner: "n",
+        it("should not send a message if bot invited itself", done => {
+
+            const event = {
+                data: {
+                    UserJoinedChannel: [{
+                        user: {
+                            isAtomistBot: "true",
+                            screenName: "atomist_bot",
+                            userId: "U1234567",
+                        },
+                        channel: {
+                            botInvitedSelf: true,
+                            channelId: "CHP87654P",
+                            name: "ponch",
+                            repos: [],
+                            team: {
+                                id: "T1L0VDKJP",
+                                orgs: [
+                                    {
+                                        owner: "n",
+                                        provider: {
+                                            apiUrl: "https://ghe.chp.gov/v3/",
                                         },
-                                    ],
+                                        repo: [
+                                            {
+                                                name: "n",
+                                                owner: "n",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        },
+                    }],
+                },
+                extensions: {
+                    type: "READ_ONLY",
+                    operationName: "BotJoinedChannel",
+                },
+            };
+
+            let silent = true;
+            const ctx: any = {
+                messageClient: {
+                    send(
+                        msg: any,
+                        destinations: Destination[],
+                        options?: MessageOptions,
+                    ): Promise<any> {
+                        silent = false;
+                        return Promise.resolve(true);
+                    },
+                },
+            };
+            const h = new BotJoinedChannel();
+            h.handle(event, ctx)
+                .then(() => {
+                    assert(silent);
+                })
+                .then(() => done(), done);
+        });
+
+        it("should send a mapped repo message", done => {
+
+            const event = {
+                data: {
+                    UserJoinedChannel: [{
+                        user: {
+                            isAtomistBot: "true",
+                            screenName: "atomist_bot",
+                            userId: "U1234567",
+                        },
+                        channel: {
+                            botInvitedSelf: false,
+                            channelId: "CHP87654P",
+                            name: "ponch",
+                            repos: [
+                                {
+                                    name: "n",
+                                    owner: "n",
+                                    org: {
+                                        provider: {
+                                            url: "https://ghe.chp.gov/",
+                                        },
+                                    },
                                 },
                             ],
+                            team: {
+                                id: "T1L0VDKJP",
+                                orgs: [
+                                    {
+                                        owner: "n",
+                                        provider: {
+                                            apiUrl: "https://ghe.chp.gov/v3/",
+                                        },
+                                        repo: [
+                                            {
+                                                name: "n",
+                                                owner: "n",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
                         },
-                    },
-                }],
-            },
-            extensions: {
-                type: "READ_ONLY",
-                operationName: "BotJoinedChannel",
-            },
-        };
+                    }],
+                },
+                extensions: {
+                    type: "READ_ONLY",
+                    operationName: "BotJoinedChannel",
+                },
+            };
 
-        it("should send a message", done => {
             let sent = false;
             const ctx: any = {
                 messageClient: {
@@ -133,6 +309,9 @@ describe("BotJoinedChannel", () => {
                         destinations: Destination[],
                         options?: MessageOptions,
                     ): Promise<any> {
+                        const m = msg as string;
+                        assert(m.includes("Hello! Now I can respond to messages beginning with @atomist_bot."));
+                        assert(m.includes("I will post GitHub notifications about <https://ghe.chp.gov/n/n|n/n>"));
                         sent = true;
                         return Promise.resolve(true);
                     },
@@ -143,7 +322,60 @@ describe("BotJoinedChannel", () => {
                 .then(() => {
                     assert(sent);
                 })
-                .then(done, done);
+                .then(() => done(), done);
+        });
+
+        it("should send a GitHub integration suggestion", done => {
+
+            const event = {
+                data: {
+                    UserJoinedChannel: [{
+                        user: {
+                            isAtomistBot: "true",
+                            screenName: "atomist_bot",
+                            userId: "U1234567",
+                        },
+                        channel: {
+                            botInvitedSelf: false,
+                            channelId: "CHP87654P",
+                            name: "ponch",
+                            repos: [],
+                            team: {
+                                id: "T1L0VDKJP",
+                                orgs: [],
+                            },
+                        },
+                    }],
+                },
+                extensions: {
+                    type: "READ_ONLY",
+                    operationName: "BotJoinedChannel",
+                },
+            };
+
+            let sent = false;
+            const ctx: any = {
+                messageClient: {
+                    send(
+                        msg: any,
+                        destinations: Destination[],
+                        options?: MessageOptions,
+                    ): Promise<any> {
+                        const m = msg as string;
+                        assert(m.includes("Hello! Now I can respond to messages beginning with @atomist_bot."));
+                        assert(m.includes("I won't be able to do much without GitHub integration, though."));
+                        assert(m.includes("Run `@atomist_bot enroll org` to set that up."));
+                        sent = true;
+                        return Promise.resolve(true);
+                    },
+                },
+            };
+            const h = new BotJoinedChannel();
+            h.handle(event, ctx)
+                .then(() => {
+                    assert(sent);
+                })
+                .then(() => done(), done);
         });
 
     });


### PR DESCRIPTION
Rather than rely on GraphQL which may have many deleted repos, get the
repos for each owner from the GitHub API.  Improve repo-channel fuzzy
match.  Account for different repositories having different GitHub API
URLs.

Fixes #59