### PR TITLE
Endless regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Provide path to GitHubApi for GHE instances [#121][121]
 -   Account for channels without names [#123][123]
 -   Fetch repositories from GitHub [#59][59]
+-   Catastrophic backtracking in image URL regular expression [#136][136]
 
 [104]: https://github.com/atomist/lifecycle-automation/issues/104
 [121]: https://github.com/atomist/lifecycle-automation/issues/121
 [123]: https://github.com/atomist/lifecycle-automation/issues/123
 [59]: https://github.com/atomist/lifecycle-automation/issues/59
+[136]: https://github.com/atomist/lifecycle-automation/issues/136
 
 ## [0.2.6][] - 2017-11-15
 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -196,10 +196,8 @@ function urlToImageAttachment(url: string): slack.Attachment {
  */
 export function extractImageUrls(body: string): slack.Attachment[] {
     const slackLinkRegExp = /<(https?:\/\/.*?)(?:\|.*?)?>/g;
-    // derived from https://stackoverflow.com/a/6927878/5464956
-    // changed to require HTTP
-    // tslint:disable-next-line:max-line-length
-    const urlRegExp = /\b(https?:\/\/(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/gi;
+    // inspired by https://stackoverflow.com/a/6927878/5464956
+    const urlRegExp = /\bhttps?:\/\/[^\s<>\[\]]+[^\s`!()\[\]{};:'".,<>?«»“”‘’]/gi;
     const attachments: slack.Attachment[] = [];
     const bodyParts = body.split(slackLinkRegExp);
     for (let i = 0; i < bodyParts.length; i++) {
@@ -221,7 +219,13 @@ export function extractImageUrls(body: string): slack.Attachment[] {
             }
         }
     }
-    return attachments;
+    const uniqueAttachments: slack.Attachment[] = [];
+    attachments.forEach(a => {
+        if (!uniqueAttachments.some(ua => ua.image_url === a.image_url)) {
+            uniqueAttachments.push(a);
+        }
+    });
+    return uniqueAttachments;
 }
 
 export function extractLinkedIssues(body: string,

--- a/test/lifecycle/rendering/AttachImagesNodeRendererTest.ts
+++ b/test/lifecycle/rendering/AttachImagesNodeRendererTest.ts
@@ -24,6 +24,26 @@ describe("AttachImagesNodeRenderer", () => {
             .then(() => done(), done);
     });
 
+    it("correctly attach 1 image from a link", done => {
+
+        const renderer = new AttachImagesNodeRenderer();
+        const node = {
+            body: "![https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif]" +
+            "(https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif)",
+        };
+        const msg: SlackMessage = {
+            attachments: [],
+        };
+
+        renderer.render(node, [], msg, null)
+            .then(rm => {
+                assert(rm.attachments.length === 1);
+                assert(rm.attachments[0].text === "giphy.gif");
+                assert(rm.attachments[0].image_url === "https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif");
+            })
+            .then(() => done(), done);
+    });
+
     it("correctly attach multiple images", done => {
 
         const renderer = new AttachImagesNodeRenderer();

--- a/test/util/helpersTest.ts
+++ b/test/util/helpersTest.ts
@@ -211,6 +211,12 @@ and https://www.nhl.com/standings/index.html.`;
             assert(a.length === 0);
         });
 
+        it("should not find image with invalid protocol", () => {
+            const b = `Nothing to see xhttp://static.atomist.com/rug/merge.jpeg`;
+            const a = extractImageUrls(b);
+            assert(a.length === 0);
+        });
+
         it("should find the image when that is all", () => {
             const b = `http://static.atomist.com/rug/merge.jpeg`;
             const a = extractImageUrls(b);
@@ -289,6 +295,42 @@ He shoots, he scores!`;
             const b = "Here's the original message: https://atomist-community.slack.com/archives/C7GHDARGU/p1515798324000172\r\n\r\nHere's the issue that triggered that message: https://github.com/atomist/lifecycle-automation/issues/103\r\n\r\nHere's the URL causing the issue: https://api.slack.com/docs/messages/builder?msg=%7B%22attachments%22%3A%5B%7B%22mrkdwn_in%22%3A%5B%22text%22%2C%22pretext%22%5D%2C%22color%22%3A%22%2345B254%22%2C%22pretext%22%3A%22Open%20issues%3A%22%2C%22author_name%22%3A%22atomisthq%2Fbot-service%22%2C%22author_link%22%3A%22http%3A%2F%2Fatomist.com%22%2C%22author_icon%22%3A%22https%3A%2F%2Fimages.atomist.com%2Frug%2Fissue-open.png%22%2C%22text%22%3A%22%3Chttp%3A%2F%2Fatomist.com%7C%23826%3A%20Use%20the%20new%20channels%20and%20users%20end%20points%20in%20Neo%3E%5Cn%3Chttp%3A%2F%2Fatomist.com%7C%23824%3A%20Some%20other%20issue%3E%22%7D%2C%7B%22mrkdwn_in%22%3A%5B%22text%22%2C%22pretext%22%5D%2C%22pretext%22%3A%22Closed%20issues%3A%22%2C%22author_name%22%3A%22atomisthq%2Fbot-service%22%2C%22author_link%22%3A%22http%3A%2F%2Fatomist.com%22%2C%22author_icon%22%3A%22https%3A%2F%2Fimages.atomist.com%2Frug%2Fissue-closed.png%22%2C%22color%22%3A%22D94649%22%2C%22text%22%3A%22%3Chttp%3A%2F%2Fatomist.com%7C%23821%3A%20Big%20bug%3E%5Cn%3Chttp%3A%2F%2Fatomist.com%7C%23821%3A%20Some%20other%20bug%3E%5Cn%3Chttp%3A%2F%2Fatomist.com%7C%2381%3A%20Awesome%20feature%3E%22%7D%2C%7B%22mrkdwn_in%22%3A%5B%22text%22%2C%22pretext%22%5D%2C%22author_name%22%3A%22atomisthq%2Fbot-service%22%2C%22author_link%22%3A%22http%3A%2F%2Fatomist.com%22%2C%22author_icon%22%3A%22https%3A%2F%2Fimages.atomist.com%2Frug%2Fpull-request-merged.png%22%2C%22pretext%22%3A%22Reviewed%20PRs%3A%22%2C%22text%22%3A%22%3Chttp%3A%2F%2Fatomist.com%7C%23820%3A%20Add%20something%20useful%3E%20by%20%3C%40kipz%3E%22%7D%5D%7D\r\n";
             const a = extractImageUrls(b);
             assert(a.length === 0);
+        });
+
+        it("should deduplicate images", () => {
+            const b = "http://static.atomist.com/rug/merge.png http://static.atomist.com/rug/merge.png";
+            const a = extractImageUrls(b);
+            assert(a.length === 1);
+            assert.deepStrictEqual(a[0], {
+                text: "merge.png",
+                image_url: "http://static.atomist.com/rug/merge.png",
+                fallback: "merge.png",
+            });
+        });
+
+        it("should not backtrack indefinitely", () => {
+            const b = "![https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif]" +
+                "(https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif)";
+            const a = extractImageUrls(b);
+            assert(a.length === 1);
+            assert.deepStrictEqual(a[0], {
+                text: "giphy.gif",
+                image_url: "https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif",
+                fallback: "giphy.gif",
+            });
+        });
+
+        it("should not backtrack indefinitely on invalid markdown", () => {
+            const b = "![https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif" +
+                "(https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif)";
+            const a = extractImageUrls(b);
+            assert(a.length === 1);
+            assert.deepStrictEqual(a[0], {
+                text: "giphy.gif",
+                // tslint:disable-next-line:max-line-length
+                image_url: "https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif(https://media2.giphy.com/media/qilPKODIJZUgo/giphy.gif",
+                fallback: "giphy.gif",
+            });
         });
 
     });


### PR DESCRIPTION
The old image extraction URL went to great lengths to ensure if
parentheses occurred within the URL, they matched.  This causes a
repetition of a repetition which led to catastrophic backtracking, see
https://www.regular-expressions.info/catastrophic.html for more
information.  Unfortunately, JavaScript regular expressions do not
support possessive quantifiers or atomist groups, so we had to modify
the regular expression to avoid the issue.  The result is that we no
longer whether parentheses in the URL match.  That said, I don't think
there's any requirement they do anyway.

While testing this I found that invalid markdown could lead to a
similar situation, so I added a test for that too.  The resulting
image link is not valid, but neither is the markdown!

Added de-duplication of image URLs in attachments.

Fixes #136