### PR TITLE
Populate owner for unlinking a repo

### DIFF
--- a/src/handlers/command/slack/ListRepoLinks.ts
+++ b/src/handlers/command/slack/ListRepoLinks.ts
@@ -58,6 +58,7 @@ export class ListRepoLinks implements HandleCommand {
                         const handler = new UnlinkRepo();
                         handler.msgId = this.msgId;
                         handler.name = r.name;
+                        handler.owner = r.owner;
 
                         const slug = `${r.owner}/${r.name}`;
                         const attachment: Attachment = {


### PR DESCRIPTION
I noticed that in atomisthq#jessitron-stream, when I link and then unlink automation-client-ts, it asks me for the owner each time.
this'll probably fix it