### PR TITLE
Permit the linking of MS Teams channels to repo with the LinkRepo command

### DIFF
--- a/src/handlers/command/slack/LinkRepo.ts
+++ b/src/handlers/command/slack/LinkRepo.ts
@@ -28,7 +28,7 @@ import {
 } from "@atomist/automation-client";
 import * as slack from "@atomist/slack-messages";
 import { LinkSlackChannelToRepo } from "../../../typings/types";
-import { isChannel } from "../../../util/slack";
+import { isChannel, isSlack } from "../../../util/slack";
 import {
     checkRepo,
     noRepoMessage,
@@ -101,7 +101,7 @@ export class LinkRepo implements HandleCommand {
     public msg: string = "";
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
-        if (!isChannel(this.channelId)) {
+        if (isSlack(this.channelId) && !isChannel(this.channelId)) {
             const err = "The Atomist Bot can only link repositories to public or private channels. " +
                 "Please try again in a public or private channel.";
             return ctx.messageClient.addressChannels(err, this.channelName)

--- a/src/handlers/command/slack/LinkRepo.ts
+++ b/src/handlers/command/slack/LinkRepo.ts
@@ -28,7 +28,10 @@ import {
 } from "@atomist/automation-client";
 import * as slack from "@atomist/slack-messages";
 import { LinkSlackChannelToRepo } from "../../../typings/types";
-import { isChannel, isSlack } from "../../../util/slack";
+import {
+    isChannel,
+    isSlack,
+} from "../../../util/slack";
 import {
     checkRepo,
     noRepoMessage,

--- a/src/util/slack.ts
+++ b/src/util/slack.ts
@@ -37,5 +37,5 @@ export function isChannel(id: string): boolean {
  * @return true if the system is Slack
  */
 export function isSlack(id: string): boolean {
-    return id.indexOf("skype") === -1;
+    return !id.includes("skype");
 }

--- a/src/util/slack.ts
+++ b/src/util/slack.ts
@@ -24,3 +24,18 @@
 export function isChannel(id: string): boolean {
     return id.indexOf("C") === 0 || id.indexOf("G") === 0;
 }
+
+/**
+ * Determine if the chat system is Slack.
+ *
+ * This is a simple implementation right now in order to add basic support
+ * for Microsoft Teams. In future we prefer not to use the channel id
+ * format to determine the chat system, but have Atomist provide us with the
+ * type of chat system in the request message.
+ *
+ * @param id channel ID
+ * @return true if the system is Slack
+ */
+export function isSlack(id: string): boolean {
+    return id.indexOf("skype") === -1;
+}

--- a/test/util/slackTest.ts
+++ b/test/util/slackTest.ts
@@ -17,7 +17,10 @@
 import "mocha";
 import * as assert from "power-assert";
 
-import { isChannel, isSlack } from "../../src/util/slack";
+import {
+    isChannel,
+    isSlack,
+} from "../../src/util/slack";
 
 describe("slack", () => {
 

--- a/test/util/slackTest.ts
+++ b/test/util/slackTest.ts
@@ -17,7 +17,7 @@
 import "mocha";
 import * as assert from "power-assert";
 
-import { isChannel } from "../../src/util/slack";
+import { isChannel, isSlack } from "../../src/util/slack";
 
 describe("slack", () => {
 
@@ -42,6 +42,20 @@ describe("slack", () => {
         it("should accept private group chats", () => {
             ["GR8W1D0PN", "G767PBQBG"].forEach(i => {
                 assert(isChannel(i));
+            });
+        });
+
+    });
+
+    describe("checkIsSlack", () => {
+
+        it("should report false for any MS Team channel ID", () => {
+            assert(!isSlack("12:a347e001ebcd4f02ab3a086c1ddb0a03@thread.skype"));
+        });
+
+        it("should report true for any other type of channel ID (good or bad)", () => {
+            ["D1LL0N123", "GR8W1D0PN", "C2KDBBLBA", "ch4r1i3", "not a real id", "" ].forEach(i => {
+                assert(isSlack(i));
             });
         });
 


### PR DESCRIPTION
This is intended to be a short-term fix while we add support for MS Teams. A better fix might require adding an attribute to the request indicating which chat system is in use. For now we choose to answer the 'isSlack' question by looking at the Channel ID format.

There was already a check to ensure that the channel is public or private (ie. not a DM), which uses the first character of the Slack channel ID. This rejects all MS Teams channels that have a different ID format, so needs changing in order to use MS Teams.