### PR TITLE
Ensuring that ChannelName is passed through to the link repo mutation.

### DIFF
--- a/src/handlers/command/slack/AssociateRepo.ts
+++ b/src/handlers/command/slack/AssociateRepo.ts
@@ -98,6 +98,9 @@ export class AssociateRepo implements HandleCommand {
     @MappedParameter(MappedParameters.SlackChannel)
     public channelId: string;
 
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public channelName: string;
+
     @MappedParameter(MappedParameters.GitHubOwner)
     public owner: string;
 
@@ -137,7 +140,8 @@ export class AssociateRepo implements HandleCommand {
                 }
                 return addBotToSlackChannel(ctx, this.teamId, this.channelId)
                     .then(() => linkSlackChannelToRepo(
-                                ctx, this.teamId, this.channelId, this.repo, this.owner, this.provider))
+                                ctx, this.teamId, this.channelId, this.channelName, this.repo, this.owner,
+                                    this.provider))
                     .then(() => inviteUserToSlackChannel(ctx, this.teamId, this.channelId, this.userId))
                     .then(() => {
                         const msg = `Linked ${bold(this.owner + "/" + this.repo)} to ` +

--- a/src/handlers/command/slack/LinkRepo.ts
+++ b/src/handlers/command/slack/LinkRepo.ts
@@ -43,6 +43,7 @@ export function linkSlackChannelToRepo(
     ctx: HandlerContext,
     teamId: string,
     channelId: string,
+    channelName: string,
     repo: string,
     owner: string,
     providerId: string,
@@ -53,6 +54,7 @@ export function linkSlackChannelToRepo(
             variables: {
                 teamId,
                 channelId,
+                channelName,
                 repo,
                 owner,
                 providerId,
@@ -116,7 +118,7 @@ export class LinkRepo implements HandleCommand {
                     return ctx.messageClient.respond(noRepoMessage(this.name, this.owner, ctx), { dashboard: false });
                 }
                 return linkSlackChannelToRepo(
-                    ctx, this.teamId, this.channelId, this.name, this.owner, this.provider)
+                    ctx, this.teamId, this.channelId, this.channelName, this.name, this.owner, this.provider)
                     .then(() => {
                         if (this.msgId) {
                             return ctx.messageClient.addressChannels(


### PR DESCRIPTION
This mutation is called from both the LinkRepo and AssociateRepo commands. Added channelName as a mapped parameter to AssociateRepo.

Context: For msteams support we cannot rely on the graph having both channelId and channelName already. It needs this mapping in order to correctly route the response (and future responses) to the correct channel.

My local build also wanted to remove a couple of lines from src/typings/types.ts, but I didn't commit them. Should I? They can't be related to my changes. The lines were:

```
    approvalRequired?: boolean | null;
    preApprovalRequired?: boolean | null;
```

