### PR TITLE
Fix LinkOwnerRepo and AssociateRepo commands

### DIFF
--- a/lib/graphql/subscription/botJoinedChannel.graphql
+++ b/lib/graphql/subscription/botJoinedChannel.graphql
@@ -25,6 +25,7 @@ subscription botJoinedChannel {
           ownerType
           provider {
             apiUrl
+            providerId
           }
           repo {
             name

--- a/lib/handlers/command/github/gitHubApi.ts
+++ b/lib/handlers/command/github/gitHubApi.ts
@@ -28,6 +28,7 @@ import { error } from "../../../util/messages";
 
 export const DefaultGitHubApiUrl = "https://api.github.com/";
 export const DefaultGitHubUrl = "https://github.com/";
+export const DefaultGitHubProviderId = "zjlmxjzwhurspem";
 
 export function api(token: string, apiUrl: string = DefaultGitHubApiUrl): GitHubApi {
     // separate the url

--- a/lib/handlers/command/slack/LinkRepo.ts
+++ b/lib/handlers/command/slack/LinkRepo.ts
@@ -33,6 +33,10 @@ import {
     isSlack,
 } from "../../../util/slack";
 import {
+    DefaultGitHubApiUrl,
+    DefaultGitHubProviderId,
+} from "../github/gitHubApi";
+import {
     checkRepo,
     noRepoMessage,
 } from "./AssociateRepo";
@@ -50,16 +54,16 @@ export function linkSlackChannelToRepo(
 ): Promise<LinkSlackChannelToRepo.Mutation> {
 
     return ctx.graphClient.mutate<LinkSlackChannelToRepo.Mutation, LinkSlackChannelToRepo.Variables>({
-            name: "linkSlackChannelToRepo",
-            variables: {
-                teamId,
-                channelId,
-                channelName,
-                repo,
-                owner,
-                providerId,
-            },
-        });
+        name: "linkSlackChannelToRepo",
+        variables: {
+            teamId,
+            channelId,
+            channelName,
+            repo,
+            owner,
+            providerId,
+        },
+    });
 }
 
 @ConfigurableCommandHandler("Link a repository and channel", {
@@ -106,23 +110,37 @@ export class LinkRepo implements HandleCommand {
     public msg: string = "";
 
     public handle(ctx: HandlerContext): Promise<HandlerResult> {
+        if (!this.channelName) {
+            const err = "No channel name was provided when invoking this command.";
+            return ctx.messageClient.respond(err)
+                .then(() => Success, failure);
+        }
         if (isSlack(this.channelId) && !isChannel(this.channelId)) {
             const err = "The Atomist Bot can only link repositories to public or private channels. " +
                 "Please try again in a public or private channel.";
             return ctx.messageClient.addressChannels(err, this.channelName)
                 .then(() => Success, failure);
         }
-        return checkRepo(this.apiUrl, this.provider, this.name, this.owner, ctx)
+        if (!this.teamId) {
+            const err = "No Slack team ID was provided when invoking this command.";
+            return ctx.messageClient.addressChannels(err, this.channelName)
+                .then(() => Success, failure);
+        }
+        const apiUrl = (this.apiUrl) ? this.apiUrl : DefaultGitHubApiUrl;
+        const provider = (this.provider) ? this.provider : DefaultGitHubProviderId;
+        return checkRepo(apiUrl, provider, this.name, this.owner, ctx)
             .then(repoExists => {
                 if (!repoExists) {
-                    return ctx.messageClient.respond(noRepoMessage(this.name, this.owner, ctx), { dashboard: false });
+                    return ctx.messageClient.respond(noRepoMessage(this.name, this.owner, ctx), { dashboard: false })
+                        .then(() => Success, failure);
                 }
-                return linkSlackChannelToRepo(
-                    ctx, this.teamId, this.channelId, this.channelName, this.name, this.owner, this.provider)
+                return linkSlackChannelToRepo(ctx, this.teamId, this.channelId, this.channelName, this.name,
+                    this.owner, this.provider)
                     .then(() => {
                         if (this.msgId) {
                             return ctx.messageClient.addressChannels(
-                                this.msg, this.channelName, { id: this.msgId, dashboard: false });
+                                this.msg, this.channelName, { id: this.msgId, dashboard: false })
+                                .then(() => Success, failure);
                         }
                         return Success;
                     });

--- a/lib/handlers/event/channellink/BotJoinedChannel.ts
+++ b/lib/handlers/event/channellink/BotJoinedChannel.ts
@@ -46,18 +46,15 @@ import {
     repoSlug,
 } from "../../../util/helpers";
 import * as github from "../../command/github/gitHubApi";
-import { LinkOwnerRepo } from "../../command/slack/LinkOwnerRepo";
+import {
+    LinkOwnerRepo,
+    RepoProvider,
+} from "../../command/slack/LinkOwnerRepo";
 import {
     DefaultBotName,
     LinkRepo,
 } from "../../command/slack/LinkRepo";
 import { NoLinkRepo } from "../../command/slack/NoLinkRepo";
-
-export interface RepoApi {
-    name: string;
-    owner: string;
-    api: string;
-}
 
 @EventHandler("Display a helpful message when the bot joins a channel", subscription("botJoinedChannel"))
 @Tags("enrollment")
@@ -112,8 +109,8 @@ I won't be able to do much without GitHub integration, though. Run \`@${botName}
             const orgs = j.channel.team.orgs.filter(o => o);
 
             return Promise.all(orgs.map(o => {
-                const repos: RepoApi[] = [];
-                const apiUrl = (o.provider && o.provider.apiUrl) ? o.provider.apiUrl : undefined;
+                const repos: RepoProvider[] = [];
+                const apiUrl = (o.provider && o.provider.apiUrl) ? o.provider.apiUrl : github.DefaultGitHubApiUrl;
                 const api = github.api(this.orgToken, apiUrl);
                 return ((o.ownerType === "user") ?
                     api.repos.getForUser({ username: o.owner, per_page: 100 }) :
@@ -125,11 +122,14 @@ I won't be able to do much without GitHub integration, though. Run \`@${botName}
                                 login: string;
                             };
                         }
+                        const providerId = (o.provider && o.provider.providerId) ?
+                            o.provider.providerId : github.DefaultGitHubProviderId;
                         const ghRepos = res.data as GitHubRepoResponse[];
                         ghRepos.forEach(ghr => repos.push({
                             name: ghr.name,
                             owner: ghr.owner.login,
-                            api: apiUrl,
+                            apiUrl,
+                            providerId,
                         }));
                         return repos;
                     })
@@ -167,11 +167,15 @@ I don't see any repositories in GitHub${ownerText}.`;
                         const linkRepo = new LinkRepo();
                         const org = orgs.find(o => o.owner === r.owner);
                         const apiUrl = (org && org.provider && org.provider.apiUrl) ?
-                            org.provider.apiUrl : undefined;
-                        linkRepo.apiUrl = apiUrl;
+                            org.provider.apiUrl : github.DefaultGitHubApiUrl;
+                        const providerId = (org && org.provider && org.provider.providerId) ?
+                            org.provider.providerId : github.DefaultGitHubProviderId;
+                        linkRepo.teamId = j.channel.team.id;
                         linkRepo.channelId = j.channel.channelId;
                         linkRepo.channelName = channelName;
                         linkRepo.owner = r.owner;
+                        linkRepo.apiUrl = apiUrl;
+                        linkRepo.provider = providerId;
                         linkRepo.name = r.name;
                         linkRepo.msgId = msgId;
                         linkRepo.msg = helloText;
@@ -183,12 +187,13 @@ I don't see any repositories in GitHub${ownerText}.`;
                             text: "repository...",
                             options: repoOptions(lolRepos),
                         };
-                        const linkRepoSlug = new LinkOwnerRepo();
-                        linkRepoSlug.channelId = j.channel.channelId;
-                        linkRepoSlug.channelName = channelName;
-                        linkRepoSlug.msgId = msgId;
-                        linkRepoSlug.msg = helloText;
-                        actions.push(menuForCommand(menu, linkRepoSlug, "slug"));
+                        const linkOwnerRepo = new LinkOwnerRepo();
+                        linkOwnerRepo.teamId = j.channel.team.id;
+                        linkOwnerRepo.channelId = j.channel.channelId;
+                        linkOwnerRepo.channelName = channelName;
+                        linkOwnerRepo.msgId = msgId;
+                        linkOwnerRepo.msg = helloText;
+                        actions.push(menuForCommand(menu, linkOwnerRepo, "repoProvider"));
                     }
 
                     const noLinkRepo = new NoLinkRepo();
@@ -220,21 +225,16 @@ OK. If you want to link a repository later, type \`${linkCmd}\``;
     }
 }
 
-function repoSlugApi(repo: RepoApi): string {
-    const api = (repo.api) ? repo.api : "";
-    return `${repoSlug(repo)}|${api}`;
-}
-
-export function repoOptions(lol: RepoApi[][]): OptionGroup[] {
+export function repoOptions(lol: RepoProvider[][]): OptionGroup[] {
     return lol.map(repos => {
         if (repos.length < 1) {
-            return null;
+            return undefined;
         }
         const owner = repos[0].owner;
         return {
             text: `${owner}/`,
             options: repos.map(r => {
-                return { text: r.name, value: repoSlugApi(r) };
+                return { text: r.name, value: JSON.stringify(r) };
             }).sort((a, b) => a.text.localeCompare(b.text)),
         };
     }).filter(og => og);

--- a/lib/handlers/event/push/PushToUnmappedRepo.ts
+++ b/lib/handlers/event/push/PushToUnmappedRepo.ts
@@ -40,6 +40,10 @@ import {
     repoChannelName,
     repoSlackLink,
 } from "../../../util/helpers";
+import {
+    DefaultGitHubApiUrl,
+    DefaultGitHubProviderId,
+} from "../../command/github/gitHubApi";
 import { SetUserPreference } from "../../command/preferences/SetUserPreference";
 import { CreateChannel } from "../../command/slack/CreateChannel";
 import {
@@ -88,7 +92,7 @@ export class PushToUnmappedRepo implements HandleEvent<graphql.PushToUnmappedRep
 
             return sendUnMappedRepoMessage(chatIds, p.repo, ctx, botNames);
         }))
-        .then(() => Success, failure);
+            .then(() => Success, failure);
     }
 
 }
@@ -119,7 +123,7 @@ export function sendUnMappedRepoMessage(
             addressSlackUsers(chatId.chatTeam.id, chatId.screenName),
             { id, dashboard: false });
     }))
-    .then(() => Success);
+        .then(() => Success);
 }
 
 /**
@@ -194,7 +198,7 @@ export function leaveRepoUnmapped(
 }
 
 function populateMapCommand(c: CreateChannel, repo: graphql.PushToUnmappedRepo.Repo, msgId: string): CreateChannel {
-    c.apiUrl = (repo.org.provider) ? repo.org.provider.apiUrl : undefined;
+    c.apiUrl = (repo.org.provider) ? repo.org.provider.apiUrl : DefaultGitHubApiUrl;
     c.owner = repo.owner;
     c.repo = repo.name;
     c.msgId = msgId;

--- a/test/handlers/event/channelLink/BotJoinedChannel.test.ts
+++ b/test/handlers/event/channelLink/BotJoinedChannel.test.ts
@@ -25,9 +25,11 @@ import {
     MessageOptions,
 } from "@atomist/automation-client/spi/message/MessageClient";
 import {
+    RepoProvider,
+} from "../../../../lib/handlers/command/slack/LinkOwnerRepo";
+import {
     BotJoinedChannel,
     fuzzyChannelRepoMatch,
-    RepoApi,
     repoOptions,
 } from "../../../../lib/handlers/event/channellink/BotJoinedChannel";
 
@@ -145,29 +147,33 @@ describe("BotJoinedChannel", () => {
 
     describe("repoOptions", () => {
 
-        const lolRepos: RepoApi[][] = [
+        const lolRepos: RepoProvider[][] = [
             [
                 {
                     name: "7-mary-3",
                     owner: "jon",
-                    api: undefined,
+                    apiUrl: undefined,
+                    providerId: undefined,
                 },
                 {
                     name: "79-charles",
                     owner: "jon",
-                    api: undefined,
+                    apiUrl: undefined,
+                    providerId: undefined,
                 },
             ],
             [
                 {
                     name: "7-mary-4",
                     owner: "ponch",
-                    api: "https://ghe.chp.gov/v3/",
+                    apiUrl: "https://ghe.chp.gov/v3/",
+                    providerId: "vneoipqjavzdpawwejsgj",
                 },
                 {
                     name: "79-mary-4",
                     owner: "ponch",
-                    api: "https://ghe.chp.gov/v3/",
+                    apiUrl: "https://ghe.chp.gov/v3/",
+                    providerId: "vneoipqjavzdpawwejsgj",
                 },
             ],
         ];
@@ -179,11 +185,11 @@ describe("BotJoinedChannel", () => {
                     options: [
                         {
                             text: "7-mary-3",
-                            value: "jon/7-mary-3|",
+                            value: JSON.stringify(lolRepos[0][0]),
                         },
                         {
                             text: "79-charles",
-                            value: "jon/79-charles|",
+                            value: JSON.stringify(lolRepos[0][1]),
                         },
                     ],
                 },
@@ -192,11 +198,11 @@ describe("BotJoinedChannel", () => {
                     options: [
                         {
                             text: "7-mary-4",
-                            value: "ponch/7-mary-4|https://ghe.chp.gov/v3/",
+                            value: JSON.stringify(lolRepos[1][0]),
                         },
                         {
                             text: "79-mary-4",
-                            value: "ponch/79-mary-4|https://ghe.chp.gov/v3/",
+                            value: JSON.stringify(lolRepos[1][1]),
                         },
                     ],
                 },

--- a/test/handlers/event/push/PushToUnmappedRepo.test.ts
+++ b/test/handlers/event/push/PushToUnmappedRepo.test.ts
@@ -19,6 +19,9 @@ import * as assert from "power-assert";
 
 import * as slack from "@atomist/slack-messages";
 
+import {
+    DefaultGitHubApiUrl,
+} from "../../../../lib/handlers/command/github/gitHubApi";
 import { DefaultBotName } from "../../../../lib/handlers/command/slack/LinkRepo";
 import {
     extractScreenNameFromMapRepoMessageId,
@@ -283,7 +286,7 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[0].type === "button");
             const command = (linkMsg.actions[0] as any).command;
             assert(command.name === "CreateChannel");
-            assert(command.parameters.apiUrl === undefined);
+            assert(command.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(command.parameters.channel === "sin-city");
             assert(command.parameters.owner === "grievous-angel");
             assert(command.parameters.repo === "sin-city");
@@ -293,7 +296,7 @@ describe("PushToUnmappedRepo", () => {
             const menuCommand = (linkMsg.actions[1] as any).command;
             assert(menuCommand.name === "CreateChannel");
             assert(menuCommand.parameterName === "channel");
-            assert(menuCommand.parameters.apiUrl === undefined);
+            assert(menuCommand.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(menuCommand.parameters.channel === undefined);
             assert(menuCommand.parameters.owner === "grievous-angel");
             assert(menuCommand.parameters.repo === "sin-city");
@@ -424,7 +427,7 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[0].type === "button");
             const command = (linkMsg.actions[0] as any).command;
             assert(command.name === "CreateChannel");
-            assert(command.parameters.apiUrl === undefined);
+            assert(command.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(command.parameters.channel === "sin-city");
             assert(command.parameters.owner === "grievous-angel");
             assert(command.parameters.repo === "sin-city");
@@ -432,7 +435,7 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[1].type === "button");
             const cmd1 = (linkMsg.actions[1] as any).command;
             assert(cmd1.name === "CreateChannel");
-            assert(cmd1.parameters.apiUrl === undefined);
+            assert(cmd1.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(cmd1.parameters.channel === "sin-city-1");
             assert(cmd1.parameters.owner === "grievous-angel");
             assert(cmd1.parameters.repo === "sin-city");
@@ -440,7 +443,7 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[2].type === "button");
             const cmd2 = (linkMsg.actions[2] as any).command;
             assert(cmd2.name === "CreateChannel");
-            assert(cmd2.parameters.apiUrl === undefined);
+            assert(cmd2.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(cmd2.parameters.channel === "sin-city-2");
             assert(cmd2.parameters.owner === "grievous-angel");
             assert(cmd2.parameters.repo === "sin-city");
@@ -457,7 +460,7 @@ describe("PushToUnmappedRepo", () => {
             const menuCommand = (linkMsg.actions[3] as any).command;
             assert(menuCommand.name === "CreateChannel");
             assert(menuCommand.parameterName === "channel");
-            assert(menuCommand.parameters.apiUrl === undefined);
+            assert(menuCommand.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(menuCommand.parameters.channel === undefined);
             assert(menuCommand.parameters.owner === "grievous-angel");
             assert(menuCommand.parameters.repo === "sin-city");
@@ -506,7 +509,7 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[0].type === "button");
             const command = (linkMsg.actions[0] as any).command;
             assert(command.name === "CreateChannel");
-            assert(command.parameters.apiUrl === undefined);
+            assert(command.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(command.parameters.channel === "sin-city");
             assert(command.parameters.owner === "grievous-angel");
             assert(command.parameters.repo === "sin-city");
@@ -514,7 +517,7 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[1].type === "button");
             const cmd1 = (linkMsg.actions[1] as any).command;
             assert(cmd1.name === "CreateChannel");
-            assert(cmd1.parameters.apiUrl === undefined);
+            assert(cmd1.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(cmd1.parameters.channel === "sin-city-1");
             assert(cmd1.parameters.owner === "grievous-angel");
             assert(cmd1.parameters.repo === "sin-city");
@@ -522,7 +525,7 @@ describe("PushToUnmappedRepo", () => {
             assert(linkMsg.actions[2].type === "button");
             const cmd2 = (linkMsg.actions[2] as any).command;
             assert(cmd2.name === "CreateChannel");
-            assert(cmd2.parameters.apiUrl === undefined);
+            assert(cmd2.parameters.apiUrl === DefaultGitHubApiUrl);
             assert(cmd2.parameters.channel === "sin-city-2");
             assert(cmd2.parameters.owner === "grievous-angel");
             assert(cmd2.parameters.repo === "sin-city");


### PR DESCRIPTION
LinkOwnerRepo was not sending all the needed information when calling
LinkRepo.  The team ID was missing, causing the error reported in
issue #247.  Add missing data including providerId, which required
modifying the event subscription for BotJoinedChannel.  Provide
default GitHub API URL and provider ID.

Make sure channelName is set when linking a channel and repo.

Fixes #247.